### PR TITLE
allow loaded assemblies to be assigned to class property for further …

### DIFF
--- a/Grand.Core/Infrastructure/AppDomainTypeFinder.cs
+++ b/Grand.Core/Infrastructure/AppDomainTypeFinder.cs
@@ -256,6 +256,7 @@ namespace Grand.Core.Infrastructure
                 {
                     var assemblyLoader = new AssemblyLoader();
                     var shadowCopiedAssembly = assemblyLoader.LoadFromAssemblyPath(dllPath);
+                    assemblyNames.Add(shadowCopiedAssembly.FullName);
                 }
                 catch (BadImageFormatException ex)
                 {


### PR DESCRIPTION
…use, this scenario prevented IGrandStartUp to be found and instances to be created on Windows 10 netcore 2.0 environment