### PR TITLE
Feature/issue #418 MailKit to replace obsolete System.Net.Mail in EmailSender (Grand.Services)

### DIFF
--- a/Grand.Framework/Infrastructure/DependencyRegistrar.cs
+++ b/Grand.Framework/Infrastructure/DependencyRegistrar.cs
@@ -49,6 +49,7 @@ using Grand.Services.Tasks;
 using Grand.Services.Tax;
 using Grand.Services.Topics;
 using Grand.Services.Vendors;
+using Microsoft.AspNetCore.StaticFiles;
 using MongoDB.Driver;
 using System;
 using System.Linq;
@@ -208,6 +209,11 @@ namespace Grand.Framework.Infrastructure
 
             builder.RegisterType<LanguageService>().As<ILanguageService>().InstancePerLifetimeScope();
             builder.RegisterType<DownloadService>().As<IDownloadService>().InstancePerLifetimeScope();
+            // TODO: Consider replacing service with static entry if EmailSender is the only user/caller
+            var provider = new FileExtensionContentTypeProvider();
+            builder.RegisterType<MimeMappingService>().As<IMimeMappingService>()
+                .WithParameter(new TypedParameter(typeof(FileExtensionContentTypeProvider), provider))
+                .InstancePerLifetimeScope();
 
             //picture service
             var useAzureBlobStorage = !String.IsNullOrEmpty(config.AzureBlobStorageConnectionString);

--- a/Grand.Services/Grand.Services.csproj
+++ b/Grand.Services/Grand.Services.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Google.Apis" Version="1.36.1" />
     <PackageReference Include="Google.Apis.AnalyticsReporting.v4" Version="1.36.1.1391" />
     <PackageReference Include="iTextSharp.LGPLv2.Core" Version="1.4.5" />
+    <PackageReference Include="MailKit" Version="2.1.2" />
     <PackageReference Include="MaxMind.GeoIP2" Version="3.0.0" />
     <PackageReference Include="System.ServiceModel.Duplex" Version="4.5.3" />
     <PackageReference Include="System.ServiceModel.Http" Version="4.5.3" />

--- a/Grand.Services/Media/IMimeMappingService.cs
+++ b/Grand.Services/Media/IMimeMappingService.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Grand.Services.Media
+{
+    public partial interface IMimeMappingService
+    {
+        string Map(string fName);
+    }
+}

--- a/Grand.Services/Media/MimeMappingService.cs
+++ b/Grand.Services/Media/MimeMappingService.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.StaticFiles;
+
+namespace Grand.Services.Media
+{
+    public partial class MimeMappingService : IMimeMappingService
+    {
+        private readonly FileExtensionContentTypeProvider _contentTypeProvider;
+
+        public MimeMappingService(FileExtensionContentTypeProvider contentTypeProvider)
+        {
+            _contentTypeProvider = contentTypeProvider;
+        }
+
+        public string Map(string filename)
+        {
+            string contentType;
+            if(!_contentTypeProvider.TryGetContentType(filename, out contentType))
+            {
+                contentType = "application/octet-stream";
+            }
+            return contentType;
+        }
+    }
+}

--- a/Grand.Services/Messages/EmailSender.cs
+++ b/Grand.Services/Messages/EmailSender.cs
@@ -144,16 +144,16 @@ namespace Grand.Services.Messages
             {
                 using (var smtpClient = new SmtpClient())
                 {
+                    smtpClient.ServerCertificateValidationCallback = (s, c, h, e) => emailAccount.UseServerCertificateValidation;
                     await smtpClient.ConnectAsync(
                         emailAccount.Host,
                         emailAccount.Port,
-                        emailAccount.EnableSsl ? SecureSocketOptions.SslOnConnect : SecureSocketOptions.None
+                        (SecureSocketOptions)emailAccount.SecureSocketOptionsId
                         ).ConfigureAwait(false);
 
                     await smtpClient.AuthenticateAsync(
-                        emailAccount.UseDefaultCredentials ?
-                            CredentialCache.DefaultNetworkCredentials :
-                            new NetworkCredential(emailAccount.Username, emailAccount.Password)
+                        emailAccount.Username, 
+                        emailAccount.Password
                         ).ConfigureAwait(false);
 
                     await smtpClient.SendAsync(message).ConfigureAwait(false);

--- a/Grand.Web/Areas/Admin/Controllers/EmailAccountController.cs
+++ b/Grand.Web/Areas/Admin/Controllers/EmailAccountController.cs
@@ -154,7 +154,7 @@ namespace Grand.Web.Areas.Admin.Controllers
                     throw new GrandException("Enter test email address");
                 if (ModelState.IsValid)
                 {
-                    _emailAccountViewModelService.SenTestEmail(emailAccount, model);
+                    _emailAccountViewModelService.SendTestEmail(emailAccount, model);
                     SuccessNotification(_localizationService.GetResource("Admin.Configuration.EmailAccounts.SendTestEmail.Success"), false);
                 }
                 else

--- a/Grand.Web/Areas/Admin/Services/EmailAccountViewModelService.cs
+++ b/Grand.Web/Areas/Admin/Services/EmailAccountViewModelService.cs
@@ -42,7 +42,7 @@ namespace Grand.Web.Areas.Admin.Services
             _emailAccountService.UpdateEmailAccount(emailAccount);
             return emailAccount;
         }
-        public virtual void SenTestEmail(EmailAccount emailAccount, EmailAccountModel model)
+        public virtual void SendTestEmail(EmailAccount emailAccount, EmailAccountModel model)
         {
             string subject = "Testing email functionality.";
             string body = "Email works fine.";

--- a/Grand.Web/Areas/Admin/Services/IEmailAccountViewModelService.cs
+++ b/Grand.Web/Areas/Admin/Services/IEmailAccountViewModelService.cs
@@ -9,6 +9,6 @@ namespace Grand.Web.Areas.Admin.Services
         EmailAccount InsertEmailAccountModel(EmailAccountModel model);
         EmailAccount UpdateEmailAccountModel(EmailAccount emailAccount, EmailAccountModel model);
         EmailAccount ChangePasswordEmailAccountModel(EmailAccount emailAccount, EmailAccountModel model);
-        void SenTestEmail(EmailAccount emailAccount, EmailAccountModel model);
+        void SendTestEmail(EmailAccount emailAccount, EmailAccountModel model);
     }
 }


### PR DESCRIPTION
Resolves #418 
Type: **feature|fix**

## Issue
System.Net.Mail is obsolete with ASP.Net Core 2.1+ Replaced with MailKit via Nuget package in Grand.Services. 

## Solution
Basically recreated the current setup of EmailSender with an implementation that uses MailKit (MimeKit).  Setup DI via Autofac to inject a Mime mapping service to easily identify Content Types of files being passed as attachments.  

## Breaking changes
nothing major that I can think of. 

## Testing
Ran through a basic email configuration with a test email. 
- Should probably write a few test cases in the future to ensure attachments are properly working and unexpected mystery things are caught and handled appropriately.  
