### PR TITLE
Set size of default picture after "remove" function in Picture template

### DIFF
--- a/Grand.Web/Areas/Admin/Views/Shared/EditorTemplates/Picture.cshtml
+++ b/Grand.Web/Areas/Admin/Views/Shared/EditorTemplates/Picture.cshtml
@@ -1,4 +1,4 @@
-﻿@model string
+@model string
 @using Grand.Core;
 @using Grand.Framework.UI;
 @{
@@ -11,12 +11,13 @@
     var clientId = "picture" + random;
     var pictureService = EngineContext.Current.Resolve<Grand.Services.Media.IPictureService>();
     var picture = pictureService.GetPictureById(Model);
+    var targetPictureSize = 100;
 }
 <div id="@(clientId + "value")">
     <input asp-for="@Model" type="hidden" />
 </div>
 <div id="@(clientId + "image")">
-    <img src="@(pictureService.GetPictureUrl(Model, targetSize: 100, showDefaultPicture: true))" />
+    <img src="@(pictureService.GetPictureUrl(Model, targetSize: targetPictureSize, showDefaultPicture: true))" />
 </div>
 @if (picture != null)
 {
@@ -86,8 +87,9 @@ else
         });
 
         $("#@(clientId + "remove")").click(function(e) {
-            $("#@(clientId + "image")").html("<img src='@pictureService.GetDefaultPictureUrl()'/>");
+            $("#@(clientId + "image")").html("<img src='@pictureService.GetDefaultPictureUrl(targetPictureSize)'/>");
             $("#@(clientId + "value") input").val(0);
+            $(".qq-upload-list").empty();
             $(this).hide();
         });
     });


### PR DESCRIPTION
Set default picture size to target picture size and hide the file upload list after removing a picture.

Type: Cosmetic

## Issue
When removing a picture in the Admin Picture editor template, the default image thumbnail does not get sized to the same size as the picture.  Also, the file selection list does not get cleared after removing a picture.

## Solution
Set the default picture size and hide the file list in the "remove" click JS function.

## Breaking changes
None.

## Testing
1) Edit a product and Upload a new picture on the Product Admin Picture page.  
2) Click "Remove picture".
3) The default "no image" picture thumbnail should be the same size as the previously uploaded picture thumbnail.  Also, the file uploader file list should now be cleared.
