### PR TITLE
Hide inventory for auction product type

### DIFF
--- a/Grand.Services/Catalog/ProductExtensions.cs
+++ b/Grand.Services/Catalog/ProductExtensions.cs
@@ -74,11 +74,7 @@ namespace Grand.Services.Catalog
                         var stockQuantity = product.GetTotalStockQuantity(warehouseId: storeContext.CurrentStore.DefaultWarehouseId);
                         if (stockQuantity > 0)
                         {
-                            stockMessage = product.DisplayStockQuantity ?
-                                //display "in stock" with stock quantity
-                                string.Format(localizationService.GetResource("Products.Availability.InStockWithQuantity"), stockQuantity) :
-                                //display "in stock" without stock quantity
-                                localizationService.GetResource("Products.Availability.InStock");
+                            stockMessage = product.GenerateInStockWithQuantityMessage(localizationService, stockQuantity);
                         }
                         else
                         {
@@ -116,11 +112,7 @@ namespace Grand.Services.Catalog
                             var stockQuantity = product.GetTotalStockQuantityForCombination(combination, warehouseId: storeContext.CurrentStore.DefaultWarehouseId);
                             if (stockQuantity > 0)
                             {
-                                stockMessage = product.DisplayStockQuantity ?
-                                    //display "in stock" with stock quantity
-                                    string.Format(localizationService.GetResource("Products.Availability.InStockWithQuantity"), stockQuantity) :
-                                    //display "in stock" without stock quantity
-                                    localizationService.GetResource("Products.Availability.InStock");
+                                stockMessage = product.GenerateInStockWithQuantityMessage(localizationService, stockQuantity);
                             }
                             else if (combination.AllowOutOfStockOrders)
                             {
@@ -154,6 +146,40 @@ namespace Grand.Services.Catalog
                     return stockMessage;
             }
             return stockMessage;
+        }
+
+        /// <summary>
+        /// Generate stock message for In Stocke with quantity(quantity > 0)
+        /// </summary>
+        /// <param name="product">Product</param>
+        /// <param name="localizationService">Localization service</param>
+        /// <param name="stockQuantity">stock quantity</param>
+        /// <returns></returns>
+        public static string GenerateInStockWithQuantityMessage(this Product product,
+            ILocalizationService localizationService, int stockQuantity)
+        {
+            #region Arguments check
+
+            if (localizationService == null)
+            {
+                throw new ArgumentNullException("localizationService");
+            }
+
+            if (stockQuantity <= 0)
+            {
+                throw new ArgumentOutOfRangeException("stockQuantity must be bigger than 0.");
+            }
+
+            #endregion
+
+            return (product.DisplayStockQuantity && product.ProductType != ProductType.Auction)
+                ?
+                //display "in stock" with stock quantity
+                string.Format(localizationService.GetResource("Products.Availability.InStockWithQuantity"),
+                    stockQuantity)
+                :
+                //display "in stock" without stock quantity
+                localizationService.GetResource("Products.Availability.InStock");
         }
 
         /// <summary>

--- a/Grand.Web/App_Data/Localization/defaultResources.grandres.xml
+++ b/Grand.Web/App_Data/Localization/defaultResources.grandres.xml
@@ -3312,6 +3312,9 @@
   <LocaleResource Name="Admin.Catalog.Products.Fields.DisplayStockQuantity.Hint">
     <Value>Check to display stock quantity. When enabled, customers will see stock quantity.</Value>
   </LocaleResource>
+  <LocaleResource Name="Admin.Catelog.Product.Fields.DisplayStockQuantity.NotAllowed">
+    <Value>DisplayStockQuantity is not allowed.</Value>
+  </LocaleResource>
   <LocaleResource Name="Admin.Catalog.Products.Fields.Download">
     <Value>Download file</Value>
   </LocaleResource>

--- a/Grand.Web/App_Data/Localization/defaultResources.grandres.xml
+++ b/Grand.Web/App_Data/Localization/defaultResources.grandres.xml
@@ -3312,7 +3312,7 @@
   <LocaleResource Name="Admin.Catalog.Products.Fields.DisplayStockQuantity.Hint">
     <Value>Check to display stock quantity. When enabled, customers will see stock quantity.</Value>
   </LocaleResource>
-  <LocaleResource Name="Admin.Catelog.Product.Fields.DisplayStockQuantity.NotAllowed">
+  <LocaleResource Name="Admin.Catalog.Product.Fields.DisplayStockQuantity.NotAllowed">
     <Value>DisplayStockQuantity is not allowed.</Value>
   </LocaleResource>
   <LocaleResource Name="Admin.Catalog.Products.Fields.Download">

--- a/Grand.Web/Areas/Admin/Validators/Catalog/ProductValidator.cs
+++ b/Grand.Web/Areas/Admin/Validators/Catalog/ProductValidator.cs
@@ -20,7 +20,7 @@ namespace Grand.Web.Areas.Admin.Validators.Catalog
             RuleFor(x => x.ProductTypeId == (int) ProductType.Auction && x.DisplayStockQuantity).Equal(false)
                 .WithMessage(
                     localizationService.GetResource(
-                        "Admin.Catelog.Product.Fields.DisplayStockQuantity.NotAllowed"));
+                        "Admin.Catalog.Product.Fields.DisplayStockQuantity.NotAllowed"));
         }
     }
 }

--- a/Grand.Web/Areas/Admin/Validators/Catalog/ProductValidator.cs
+++ b/Grand.Web/Areas/Admin/Validators/Catalog/ProductValidator.cs
@@ -16,6 +16,11 @@ namespace Grand.Web.Areas.Admin.Validators.Catalog
                 RuleFor(x => x.AuctionEnded && x.ProductTypeId == (int)ProductType.Auction).Equal(false).WithMessage(localizationService.GetResource("Admin.Catalog.Products.Cannoteditauction"));
 
             RuleFor(x => x.ProductTypeId == (int)ProductType.Auction && !x.AvailableEndDateTime.HasValue).Equal(false).WithMessage(localizationService.GetResource("Admin.Catalog.Products.Fields.AvailableEndDateTime.Required"));
+
+            RuleFor(x => x.ProductTypeId == (int) ProductType.Auction && x.DisplayStockQuantity).Equal(false)
+                .WithMessage(
+                    localizationService.GetResource(
+                        "Admin.Catelog.Product.Fields.DisplayStockQuantity.NotAllowed"));
         }
     }
 }

--- a/Tests/Grand.Services.Tests/Grand.Services.Tests.csproj
+++ b/Tests/Grand.Services.Tests/Grand.Services.Tests.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="NSubstitute" Version="4.0.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Add: Displaystockquantity validation on product maintaince
Add: Admin.Catelog.Product.Fields.DisplayStockQuantity.NotAllowed default resource
Add: Hide inventory for auction product type on product page
Refact: Extract GenerateInStockWithQuantityMessage method and it's unit tests

Resolves #212
Type: **feature**
