### PR TITLE
Fix for #488 - Missing if statement on home page polls.

### DIFF
--- a/Grand.Web/Views/Shared/Components/HomePagePolls/Default.cshtml
+++ b/Grand.Web/Views/Shared/Components/HomePagePolls/Default.cshtml
@@ -1,6 +1,9 @@
 ﻿@model IList<PollModel>
 <div class="col-12 px-0 home-page-polls">
-        <h2 class="generalTitle text-center">@T("Polls.Title")</h2>
+        @if (Model.Count > 0)
+        {
+            <h2 class="generalTitle text-center">@T("Polls.Title")</h2>
+        }
         @foreach (var poll in Model)
         {
             <partial name="_Poll" model="poll" />


### PR DESCRIPTION
Fix for #488 - Missing if statement on home page polls.

Resolves #488 
Type: **bugfix**

## Solution
Added a if condition to check the total count of the polls. If there are any polls then the "Community poll" heading will be visible else it will be hidden.

## Breaking changes
None
