### PR TITLE
Fixed #485: Fix problem with "Subscribed on" date on Newsletter Subscribers page

### DIFF
--- a/Grand.Web/Areas/Admin/Controllers/NewsLetterSubscriptionController.cs
+++ b/Grand.Web/Areas/Admin/Controllers/NewsLetterSubscriptionController.cs
@@ -127,7 +127,7 @@ namespace Grand.Web.Areas.Admin.Controllers
 					var m = x.ToModel();
 				    var store = _storeService.GetStoreById(x.StoreId);
 				    m.StoreName = store != null ? store.Name : "Unknown store";
-					m.CreatedOn = _dateTimeHelper.ConvertToUserTime(x.CreatedOnUtc, DateTimeKind.Utc).ToLongTimeString();
+					m.CreatedOn = _dateTimeHelper.ConvertToUserTime(x.CreatedOnUtc, DateTimeKind.Utc).ToString();
                     m.Categories = GetCategoryNames(x.Categories.ToList());
                     return m;
 				}),

--- a/Grand.Web/Areas/Admin/Controllers/NewsLetterSubscriptionController.cs
+++ b/Grand.Web/Areas/Admin/Controllers/NewsLetterSubscriptionController.cs
@@ -127,7 +127,7 @@ namespace Grand.Web.Areas.Admin.Controllers
 					var m = x.ToModel();
 				    var store = _storeService.GetStoreById(x.StoreId);
 				    m.StoreName = store != null ? store.Name : "Unknown store";
-					m.CreatedOn = x.CreatedOnUtc.Date.Month + "/" + x.CreatedOnUtc.Date.Day + "/" + x.CreatedOnUtc.Date.Year + " " + _dateTimeHelper.ConvertToUserTime(x.CreatedOnUtc, DateTimeKind.Utc).ToLongTimeString();
+					m.CreatedOn = _dateTimeHelper.ConvertToUserTime(x.CreatedOnUtc, DateTimeKind.Utc).ToLongTimeString();
                     m.Categories = GetCategoryNames(x.Categories.ToList());
                     return m;
 				}),

--- a/Grand.Web/Areas/Admin/Controllers/NewsLetterSubscriptionController.cs
+++ b/Grand.Web/Areas/Admin/Controllers/NewsLetterSubscriptionController.cs
@@ -127,7 +127,7 @@ namespace Grand.Web.Areas.Admin.Controllers
 					var m = x.ToModel();
 				    var store = _storeService.GetStoreById(x.StoreId);
 				    m.StoreName = store != null ? store.Name : "Unknown store";
-					m.CreatedOn = _dateTimeHelper.ConvertToUserTime(x.CreatedOnUtc, DateTimeKind.Utc).ToLongTimeString();
+					m.CreatedOn = x.CreatedOnUtc.Date.Month + "/" + x.CreatedOnUtc.Date.Day + "/" + x.CreatedOnUtc.Date.Year + " " + _dateTimeHelper.ConvertToUserTime(x.CreatedOnUtc, DateTimeKind.Utc).ToLongTimeString();
                     m.Categories = GetCategoryNames(x.Categories.ToList());
                     return m;
 				}),


### PR DESCRIPTION
Fix problem with "Subscribed on" date on Newsletter Subscribers page.

Resolves #485 
Type: **bugfix**

## Issue
Date in the gird always remains the same.

## Solution
The function **ConvertToUserTime** from the **DateTimeHelper** class is returning the time (and not date) in UTC but the format set for the grid is of type date. Because of this when only time is passed to the grid column, the grid control automatically renders it with the current date. In this pull request I have concatenate to set the date month and year along with the time. If there is any other way to do it, then do let me know.

## Breaking changes
None