### PR TITLE
Added CustomerNavigationModel to account_navigation_after zone.

### DIFF
--- a/Grand.Web/Views/Shared/Components/CustomerNavigation/Default.cshtml
+++ b/Grand.Web/Views/Shared/Components/CustomerNavigation/Default.cshtml
@@ -129,6 +129,6 @@
                                                                      {<text>inactive</text>}"><span class="material-icons">supervisor_account</span><span>@T("Account.VendorInfo")</span></a>
                                                                 </li>
                                                             }
-            @await Component.InvokeAsync("Widget", new { widgetZone = "account_navigation_after" })
+            @await Component.InvokeAsync("Widget", new { widgetZone = "account_navigation_after", additionalData=Model })
         </ul>
 </div>


### PR DESCRIPTION
Widget account_navigation_after should known current CustomerNavigationModel. Now it can highlight another link.