### PR TITLE
Fix Blog post removal, doesn't make the SeName inactive

### DIFF
--- a/Grand.Services/Blogs/BlogService.cs
+++ b/Grand.Services/Blogs/BlogService.cs
@@ -2,6 +2,7 @@ using Grand.Core;
 using Grand.Core.Data;
 using Grand.Core.Domain.Blogs;
 using Grand.Core.Domain.Catalog;
+using Grand.Core.Domain.Seo;
 using Grand.Services.Events;
 using MongoDB.Driver;
 using MongoDB.Driver.Linq;
@@ -23,6 +24,7 @@ namespace Grand.Services.Blogs
         private readonly IRepository<BlogComment> _blogCommentRepository;
         private readonly IRepository<BlogCategory> _blogCategoryRepository;
         private readonly IRepository<BlogProduct> _blogProductRepository;
+        private readonly IRepository<UrlRecord> _urlRecordRepository;
         private readonly CatalogSettings _catalogSettings;
         private readonly IEventPublisher _eventPublisher;
 
@@ -34,6 +36,7 @@ namespace Grand.Services.Blogs
             IRepository<BlogComment> blogCommentRepository,
             IRepository<BlogCategory> blogCategoryRepository,
             IRepository<BlogProduct> blogProductRepository,
+            IRepository<UrlRecord> urlRecordRepository,
             CatalogSettings catalogSettings,
             IEventPublisher eventPublisher)
         {
@@ -41,6 +44,7 @@ namespace Grand.Services.Blogs
             this._blogCommentRepository = blogCommentRepository;
             this._blogCategoryRepository = blogCategoryRepository;
             this._blogProductRepository = blogProductRepository;
+            this._urlRecordRepository = urlRecordRepository;
             this._catalogSettings = catalogSettings;
             this._eventPublisher = eventPublisher;
         }
@@ -53,12 +57,14 @@ namespace Grand.Services.Blogs
         /// Deletes a blog post
         /// </summary>
         /// <param name="blogPost">Blog post</param>
-        public virtual async Task DeleteBlogPost(BlogPost blogPost)
+        public virtual async Task DeleteBlogPost(BlogPost blogPost, UrlRecord urlRecord)
         {
             if (blogPost == null)
                 throw new ArgumentNullException("blogPost");
 
             await _blogPostRepository.DeleteAsync(blogPost);
+
+            await _urlRecordRepository.UpdateAsync(urlRecord);
 
             //event notification
             await _eventPublisher.EntityDeleted(blogPost);

--- a/Grand.Services/Blogs/IBlogService.cs
+++ b/Grand.Services/Blogs/IBlogService.cs
@@ -1,5 +1,6 @@
 using Grand.Core;
 using Grand.Core.Domain.Blogs;
+using Grand.Core.Domain.Seo;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -15,7 +16,7 @@ namespace Grand.Services.Blogs
         /// Deletes a blog post
         /// </summary>
         /// <param name="blogPost">Blog post</param>
-        Task DeleteBlogPost(BlogPost blogPost);
+        Task DeleteBlogPost(BlogPost blogPost, UrlRecord urlRecord);
 
         /// <summary>
         /// Gets a blog post

--- a/Grand.Web/Areas/Admin/Controllers/BlogController.cs
+++ b/Grand.Web/Areas/Admin/Controllers/BlogController.cs
@@ -29,19 +29,21 @@ namespace Grand.Web.Areas.Admin.Controllers
         private readonly ILanguageService _languageService;
         private readonly ILocalizationService _localizationService;
         private readonly IStoreService _storeService;
+        private readonly IUrlRecordService _urlRecordService;
 
         #endregion
 
         #region Constructors
 
         public BlogController(IBlogService blogService, IBlogViewModelService blogViewModelService, ILanguageService languageService, ILocalizationService localizationService,
-            IStoreService storeService)
+            IStoreService storeService, IUrlRecordService urlRecordService)
         {
             this._blogService = blogService;
             this._blogViewModelService = blogViewModelService;
             this._languageService = languageService;
             this._localizationService = localizationService;
             this._storeService = storeService;
+            this._urlRecordService = urlRecordService;
         }
 
         #endregion
@@ -162,9 +164,17 @@ namespace Grand.Web.Areas.Admin.Controllers
                 //No blog post found with the specified id
                 return RedirectToAction("List");
 
+            var urlRecord = await _urlRecordService.GetBySlug(blogPost.SeName);
+            if (urlRecord == null)
+            {
+                //No url record found with the SeName
+                return RedirectToAction("List");
+            }
+
             if (ModelState.IsValid)
             {
-                await _blogService.DeleteBlogPost(blogPost);
+                urlRecord.IsActive = false;
+                await _blogService.DeleteBlogPost(blogPost, urlRecord);
 
                 SuccessNotification(_localizationService.GetResource("Admin.ContentManagement.Blog.BlogPosts.Deleted"));
                 return RedirectToAction("List");


### PR DESCRIPTION
Resolves #506  
Type: **bugfix**

## Issue
[Blog post removal, doesn't make the SeName inactive #506](https://github.com/grandnode/grandnode/issues/506)

## Solution
Update UrlRecord.IsActive to False

## Breaking changes
no

## Testing
1. Go to Admin panel -> Content Management -> Blog -> Blog post
2. Delete one of blog post
3. Go to System -> Search Engine Friendly Names -> Search for deleted blog post
4. As result we would't see active SeName
