### PR TITLE
Nested Topics

### DIFF
--- a/Grand.Core/Domain/Topics/Topic.cs
+++ b/Grand.Core/Domain/Topics/Topic.cs
@@ -105,6 +105,7 @@ namespace Grand.Core.Domain.Topics
         /// Gets or sets a value indicating whether the entity is limited/restricted to certain stores
         /// </summary>
         public bool LimitedToStores { get; set; }
+
         public IList<string> Stores { get; set; }
 
         /// <summary>
@@ -116,7 +117,12 @@ namespace Grand.Core.Domain.Topics
         /// Gets or sets a value indicating whether the entity is subject to ACL
         /// </summary>
         public bool SubjectToAcl { get; set; }
+
         public IList<string> CustomerRoles { get; set; }
 
+        /// <summary>
+        /// Gets or sets optional parent topic id, under which this topic should be nested
+        /// </summary>
+        public string ParentTopicId { get; set; }
     }
 }

--- a/Grand.Web/App_Data/Localization/defaultResources.grandres.xml
+++ b/Grand.Web/App_Data/Localization/defaultResources.grandres.xml
@@ -10074,6 +10074,12 @@
   <LocaleResource Name="Admin.ContentManagement.Topics.Fields.SystemName.Required">
     <Value>Enter system name.</Value>
   </LocaleResource>
+  <LocaleResource Name="Admin.ContentManagement.Topics.Fields.ParentTopicId">
+    <Value>Parent topic</Value>
+  </LocaleResource>
+  <LocaleResource Name="Admin.ContentManagement.Topics.Fields.ParentTopicId.Hint">
+    <Value>System name of parent topic, under which this one will be nested.</Value>
+  </LocaleResource>
   <LocaleResource Name="Admin.ContentManagement.Topics.Fields.Title">
     <Value>Title</Value>
   </LocaleResource>

--- a/Grand.Web/Areas/Admin/Models/Topics/TopicModel.cs
+++ b/Grand.Web/Areas/Admin/Models/Topics/TopicModel.cs
@@ -32,6 +32,9 @@ namespace Grand.Web.Areas.Admin.Models.Topics
         
         public string SystemName { get; set; }
 
+        [GrandResourceDisplayName("Admin.ContentManagement.Topics.Fields.ParentTopicId")]
+        public string ParentTopicId { get; set; }
+
         [GrandResourceDisplayName("Admin.ContentManagement.Topics.Fields.IncludeInSitemap")]
         public bool IncludeInSitemap { get; set; }
 

--- a/Grand.Web/Areas/Admin/Views/Topic/_CreateOrUpdate.TabInfo.cshtml
+++ b/Grand.Web/Areas/Admin/Views/Topic/_CreateOrUpdate.TabInfo.cshtml
@@ -63,6 +63,15 @@ function togglePassword() {
                 <span asp-validation-for="SystemName"></span>
             </div>
         </div>
+
+        <div class="form-group">
+            <admin-label asp-for="ParentTopicId" />
+            <div class="col-md-9 col-sm-9">
+                <admin-input asp-for="ParentTopicId" />
+                <span asp-validation-for="ParentTopicId"></span>
+            </div>
+        </div>
+
         @if (!string.IsNullOrEmpty(Model.Id))
         {
             <div class="form-group">
@@ -77,7 +86,7 @@ function togglePassword() {
             <div class="col-md-9 col-sm-9">
                 <label class="mt-checkbox mt-checkbox-outline control control-checkbox">
                     <admin-input asp-for="IsPasswordProtected" />
-                     <div class="control__indicator"></div>
+                    <div class="control__indicator"></div>
                 </label>
                 <span asp-validation-for="IsPasswordProtected"></span>
             </div>
@@ -94,7 +103,7 @@ function togglePassword() {
             <div class="col-md-9 col-sm-9">
                 <label class="mt-checkbox mt-checkbox-outline control control-checkbox">
                     <admin-input asp-for="IncludeInSitemap" />
-                     <div class="control__indicator"></div>
+                    <div class="control__indicator"></div>
                 </label>
                 <span asp-validation-for="IncludeInSitemap"></span>
             </div>
@@ -104,7 +113,7 @@ function togglePassword() {
             <div class="col-md-9 col-sm-9">
                 <label class="mt-checkbox mt-checkbox-outline control control-checkbox">
                     <admin-input asp-for="IncludeInTopMenu" />
-                     <div class="control__indicator"></div>
+                    <div class="control__indicator"></div>
                 </label>
                 <span asp-validation-for="IncludeInTopMenu"></span>
             </div>
@@ -114,7 +123,7 @@ function togglePassword() {
             <div class="col-md-9 col-sm-9">
                 <label class="mt-checkbox mt-checkbox-outline control control-checkbox">
                     <admin-input asp-for="IncludeInFooterColumn1" />
-                     <div class="control__indicator"></div>
+                    <div class="control__indicator"></div>
                 </label>
                 <span asp-validation-for="IncludeInFooterColumn1"></span>
             </div>
@@ -124,7 +133,7 @@ function togglePassword() {
             <div class="col-md-9 col-sm-9">
                 <label class="mt-checkbox mt-checkbox-outline control control-checkbox">
                     <admin-input asp-for="IncludeInFooterColumn2" />
-                     <div class="control__indicator"></div>
+                    <div class="control__indicator"></div>
                 </label>
                 <span asp-validation-for="IncludeInFooterColumn2"></span>
             </div>
@@ -134,7 +143,7 @@ function togglePassword() {
             <div class="col-md-9 col-sm-9">
                 <label class="mt-checkbox mt-checkbox-outline control control-checkbox">
                     <admin-input asp-for="IncludeInFooterColumn3" />
-                     <div class="control__indicator"></div>
+                    <div class="control__indicator"></div>
                 </label>
                 <span asp-validation-for="IncludeInFooterColumn3"></span>
             </div>
@@ -151,7 +160,7 @@ function togglePassword() {
             <div class="col-md-9 col-sm-9">
                 <label class="mt-checkbox mt-checkbox-outline control control-checkbox">
                     <admin-input asp-for="AccessibleWhenStoreClosed" />
-                     <div class="control__indicator"></div>
+                    <div class="control__indicator"></div>
                 </label>
                 <span asp-validation-for="AccessibleWhenStoreClosed"></span>
             </div>

--- a/Grand.Web/Models/Catalog/TopMenuModel.cs
+++ b/Grand.Web/Models/Catalog/TopMenuModel.cs
@@ -34,6 +34,8 @@ namespace Grand.Web.Models.Catalog
         {
             public string Name { get; set; }
             public string SeName { get; set; }
+            public string SystemName { get; set; }
+            public IList<TopMenuTopicModel> Children { get; set; } = new List<TopMenuTopicModel>();
         }
 
         public class TopMenuManufacturerModel : BaseGrandEntityModel

--- a/Grand.Web/Models/Topics/TopicModel.cs
+++ b/Grand.Web/Models/Topics/TopicModel.cs
@@ -23,5 +23,7 @@ namespace Grand.Web.Models.Topics
         public string SeName { get; set; }
 
         public string TopicTemplateId { get; set; }
+
+        public string ParentTopicId { get; set; }
     }
 }

--- a/Grand.Web/Themes/DefaultClean/Content/css/style.css
+++ b/Grand.Web/Themes/DefaultClean/Content/css/style.css
@@ -949,8 +949,13 @@ ul.ui-autocomplete li img {
 	padding-top: 0;
 	padding-bottom: 0;
 }
+
+.mainNav .nav-item-back {
+    display: none;
+}
+
 .navbar-inner {
-	min-height: 60px;
+    min-height: 60px;
 }
 .navbar .brand {
 	padding: 0 10px;
@@ -4599,7 +4604,18 @@ footer .socicon-pinterest:hover {
         padding: 14px 25px;
         color: #1D1F20;
         font-size: 14px;
+        cursor: pointer;
     }
+
+    .mobile-menu .nav-item-back .nav-link {
+        display: flex;
+        justify-content: space-between;
+        padding: 14px 25px;
+        color: #1D1F20;
+        font-size: 14px;
+        cursor: pointer;
+    }
+
     .mobile-menu .nav-item .nav-link .arrow-down {
         color: #1D1F20;
         transform: rotate(-90deg);

--- a/Grand.Web/Views/Shared/Components/TopMenu/Default.cshtml
+++ b/Grand.Web/Views/Shared/Components/TopMenu/Default.cshtml
@@ -1,79 +1,78 @@
 ﻿@model TopMenuModel
-    @await Component.InvokeAsync("Widget", new { widgetZone = "header_menu_before" })
-    @if (Model.DisplayHomePageMenu)
-    {
-        <li class="nav-item"><a class="nav-link" href="@Url.RouteUrl("HomePage")">@T("HomePage")</a></li>
-    }
-    @{
-        var rootCategories = Model.Categories.ToList();
-    }
-    @foreach (var category in rootCategories)
-    {
-        var categoryLineModel = new TopMenuModel.CategoryLineModel
-        {
-            Category = category
-        };
-        <partial name="_CategoryLine.TopMenu" model="categoryLineModel" />
-    }
 
-    @foreach (var topic in Model.Topics)
+@await Component.InvokeAsync("Widget", new { widgetZone = "header_menu_before" })
+@if (Model.DisplayHomePageMenu)
+{
+    <li class="nav-item"><a class="nav-link" href="@Url.RouteUrl("HomePage")">@T("HomePage")</a></li>
+}
+@{
+    var rootCategories = Model.Categories.ToList();
+}
+@foreach (var category in rootCategories)
+{
+    var categoryLineModel = new TopMenuModel.CategoryLineModel
     {
-        <li class="nav-item"><a class="pl-3 nav-link" href="@Url.RouteUrl("Topic", new { SeName=topic.SeName })">@topic.Name</a></li>
-    }
-    @if (Model.Manufacturers.Any())
+        Category = category
+    };
+    <partial name="_CategoryLine.TopMenu" model="categoryLineModel" />
+}
+
+<partial name="_Topic.TopMenu" model="Model.Topics"/>
+
+@if (Model.Manufacturers.Any())
+{
+    <li class="nav-item dropdown manufacturer-items d-lg-flex d-none">
+        <a class="nav-link dropdown-toggle" href="@Url.RouteUrl("ManufacturerList")" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <span>@T("Manufacturers.Menu")</span>
+            <span class="mdi mdi-chevron-down arrow-down"></span>
+        </a>
+        <ul class="dropdown-menu manufacturer-dropdown first-level">
+            @foreach (var manuf in Model.Manufacturers)
+            {
+                <li class="nav-item">
+                    <a class="nav-link" href="@Url.RouteUrl("Manufacturer", new { SeName = manuf.SeName })">
+                        @if (!string.IsNullOrEmpty(manuf.Icon))
+                        {
+                            <span class="category-icon @manuf.Icon"></span>
+                        }
+                        @manuf.Name
+                    </a>
+                </li>
+            }
+        </ul>
+    </li>
+}
+@if (Model.DisplaySearchMenu | Model.DisplayNewProductsMenu | Model.DisplayCustomerMenu | Model.DisplayBlogMenu | Model.DisplayForumsMenu | Model.DisplayContactUsMenu)
+{
+    <li class="blank-link"></li>
+    @if (Model.NewProductsEnabled && Model.DisplayNewProductsMenu)
     {
-        <li class="nav-item dropdown manufacturer-items d-lg-flex d-none">
-            <a class="nav-link dropdown-toggle" href="@Url.RouteUrl("ManufacturerList")" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <span>@T("Manufacturers.Menu")</span>
-                <span class="mdi mdi-chevron-down arrow-down"></span>
-            </a>
-            <ul class="dropdown-menu manufacturer-dropdown first-level">
-                @foreach (var manuf in Model.Manufacturers)
-                {
-                    <li class="nav-item">
-                        <a class="nav-link" href="@Url.RouteUrl("Manufacturer", new { SeName = manuf.SeName })">
-                            @if (!string.IsNullOrEmpty(manuf.Icon))
-                            {
-                                <span class="category-icon @manuf.Icon"></span>
-                            }
-                            @manuf.Name
-                        </a>
-                    </li>
-                }
-            </ul>
+        <li class="nav-item solo-link-item">
+            <a class="nav-link" href="@Url.RouteUrl("NewProducts")">@T("Products.NewProducts")</a>
         </li>
     }
-    @if (Model.DisplaySearchMenu | Model.DisplayNewProductsMenu | Model.DisplayCustomerMenu | Model.DisplayBlogMenu | Model.DisplayForumsMenu | Model.DisplayContactUsMenu)
+    @if (Model.DisplaySearchMenu)
     {
-                <li class="blank-link"></li>
-                @if (Model.NewProductsEnabled && Model.DisplayNewProductsMenu)
-                {
-                    <li class="nav-item solo-link-item">
-                        <a class="nav-link" href="@Url.RouteUrl("NewProducts")">@T("Products.NewProducts")</a>
-                    </li>
-                }
-                @if (Model.DisplaySearchMenu)
-                {
-                    <li class="nav-item solo-link-item"><a class="nav-link" href="@Url.RouteUrl("ProductSearch")">@T("Search")</a></li>
-                }
-                @if (Model.DisplayCustomerMenu)
-                {
-                    <li class="nav-item solo-link-item"><a class="nav-link" href="@Url.RouteUrl("CustomerInfo")">@T("Account.MyAccount")</a></li>
-                }
-                @if (Model.BlogEnabled && Model.DisplayBlogMenu)
-                {
-                    <li class="nav-item solo-link-item"><a class="nav-link" href="@Url.RouteUrl("Blog")">@T("Blog")</a></li>
-                }
-                @if (Model.ForumEnabled && Model.DisplayForumsMenu)
-                {
-                    <li class="nav-item"><a class="nav-link" href="@Url.RouteUrl("Boards")">@T("Forum.Forums")</a></li>
-                }
-                @if (Model.DisplayContactUsMenu)
-                {
-                    <li class="nav-item solo-link-item"><a class="nav-link" href="@Url.RouteUrl("ContactUs")">@T("ContactUs")</a></li>
-                }
+        <li class="nav-item solo-link-item"><a class="nav-link" href="@Url.RouteUrl("ProductSearch")">@T("Search")</a></li>
     }
-    @await Component.InvokeAsync("Widget", new { widgetZone = "header_menu_after" })
+    @if (Model.DisplayCustomerMenu)
+    {
+        <li class="nav-item solo-link-item"><a class="nav-link" href="@Url.RouteUrl("CustomerInfo")">@T("Account.MyAccount")</a></li>
+    }
+    @if (Model.BlogEnabled && Model.DisplayBlogMenu)
+    {
+        <li class="nav-item solo-link-item"><a class="nav-link" href="@Url.RouteUrl("Blog")">@T("Blog")</a></li>
+    }
+    @if (Model.ForumEnabled && Model.DisplayForumsMenu)
+    {
+        <li class="nav-item"><a class="nav-link" href="@Url.RouteUrl("Boards")">@T("Forum.Forums")</a></li>
+    }
+    @if (Model.DisplayContactUsMenu)
+    {
+        <li class="nav-item solo-link-item"><a class="nav-link" href="@Url.RouteUrl("ContactUs")">@T("ContactUs")</a></li>
+    }
+}
+@await Component.InvokeAsync("Widget", new { widgetZone = "header_menu_after" })
 
 @{
     var rootCategoriesResponsive = Model.Categories.ToList();

--- a/Grand.Web/Views/Shared/_Topic.TopMenu.cshtml
+++ b/Grand.Web/Views/Shared/_Topic.TopMenu.cshtml
@@ -1,0 +1,21 @@
+﻿@model IEnumerable<TopMenuModel.TopMenuTopicModel>
+
+@foreach (var topic in Model)
+{
+    if (!topic.Children.Any())
+    {
+        <li class="nav-item"><a class="pl-3 nav-link" href="@Url.RouteUrl("Topic", new { SeName=topic.SeName })">@topic.Name</a></li>
+    }
+    else
+    {
+        <li class="nav-item dropdown">
+            <span class="pl-3 nav-link" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="true">@topic.Name</span>
+            <ul class="dropdown-menu">
+                <li class="nav-item-back">
+                    <span class="pl-3 nav-link" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="False">&larr; @T("Common.Back")</span>
+                </li>
+                <partial name="_Topic.TopMenu" model="topic.Children" />
+            </ul>
+        </li>
+    }
+}

--- a/Grand.Web/web.config
+++ b/Grand.Web/web.config
@@ -7,6 +7,7 @@
     <aspNetCore requestTimeout="23:00:00" processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" forwardWindowsAuthToken="false" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" startupTimeLimit="3600">
       <environmentVariables>
         <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Development" />
+        <environmentVariable name="COMPLUS_ForceENC" value="1" />
       </environmentVariables>
     </aspNetCore>
     <httpProtocol>

--- a/Grand.Web/web.config
+++ b/Grand.Web/web.config
@@ -7,7 +7,6 @@
     <aspNetCore requestTimeout="23:00:00" processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" forwardWindowsAuthToken="false" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" startupTimeLimit="3600">
       <environmentVariables>
         <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Development" />
-        <environmentVariable name="COMPLUS_ForceENC" value="1" />
       </environmentVariables>
     </aspNetCore>
     <httpProtocol>


### PR DESCRIPTION
Type: **feature**

## Summary
Added ability to create nested hierarchy of topics/cms pages.
In topic's edit page you can now set ParentTopicId value, if that value is set then page will be nested under given parent in top menu.

## Testing
1. Create some Topic in CMS, check **include in top menu**.
2. Create another Topic in CMS but this time in **Parent topic** field input the **SystemName** of the topic created in step 1. Also check **include in top menu**. Repeat couple of times.
3. Refresh the client page, you will see inactive-link to the topic from step 1 and when you hover over it dropdown will show up with link from step2.
4. Switch to mobile view, link from step 1 should be visible and once clicked menu should switch to view of links from step 2 with additional back button at the top.
5. Click back button, you should be returned to previous menu.