### PR TITLE
Updating page OnePageCheckout. Section "PaymentInfo" will check if ap…

### DIFF
--- a/Grand.Web/Controllers/CheckoutController.cs
+++ b/Grand.Web/Controllers/CheckoutController.cs
@@ -634,16 +634,7 @@ namespace Grand.Web.Controllers
             }
 
             //filter by country
-            string filterByCountryId = "";
-            if (_addressViewModelService.AddressSettings().CountryEnabled &&
-                _workContext.CurrentCustomer.BillingAddress != null &&
-                !String.IsNullOrEmpty(_workContext.CurrentCustomer.BillingAddress.CountryId))
-            {
-                filterByCountryId = _workContext.CurrentCustomer.BillingAddress.CountryId;
-            }
-
-            //model
-            var paymentMethodModel = await _checkoutViewModelService.PreparePaymentMethod(cart, filterByCountryId);
+            var paymentMethodModel = await GetCheckoutPaymentMethodModel(cart);
 
             if (_paymentSettings.BypassPaymentMethodSelectionIfOnlyOne &&
                 paymentMethodModel.PaymentMethods.Count == 1 && !paymentMethodModel.DisplayRewardPoints)
@@ -660,6 +651,7 @@ namespace Grand.Web.Controllers
 
             return View(paymentMethodModel);
         }
+
         [HttpPost, ActionName("PaymentMethod")]
         [FormValueRequired("nextstep")]
         public virtual async Task<IActionResult> SelectPaymentMethod(string paymentmethod, CheckoutPaymentMethodModel model)
@@ -1074,11 +1066,14 @@ namespace Grand.Web.Controllers
             if ((_workContext.CurrentCustomer.IsGuest() && !_orderSettings.AnonymousCheckoutAllowed))
                 return Challenge();
 
+            var paymentMethodModel = await GetCheckoutPaymentMethodModel(cart);
+
             var model = new OnePageCheckoutModel
             {
                 ShippingRequired = cart.RequiresShipping(),
                 DisableBillingAddressCheckoutStep = _orderSettings.DisableBillingAddressCheckoutStep,
-                BillingAddress = await _checkoutViewModelService.PrepareBillingAddress(cart, prePopulateNewAddressWithCustomerFields: true)
+                BillingAddress = await _checkoutViewModelService.PrepareBillingAddress(cart, prePopulateNewAddressWithCustomerFields: true),
+                HasSinglePaymentMethod = paymentMethodModel.PaymentMethods?.Count == 1 
             };
             return View(model);
         }
@@ -1682,6 +1677,20 @@ namespace Grand.Web.Controllers
                 _logger.Warning(exc.Message, exc, _workContext.CurrentCustomer);
                 return Content(exc.Message);
             }
+        }
+
+        private async Task<CheckoutPaymentMethodModel> GetCheckoutPaymentMethodModel(IList<ShoppingCartItem> cart)
+        {
+            var filterByCountryId = "";
+            if (_addressViewModelService.AddressSettings().CountryEnabled &&
+                _workContext.CurrentCustomer.BillingAddress != null &&
+                !string.IsNullOrWhiteSpace(_workContext.CurrentCustomer.BillingAddress.CountryId))
+            {
+                filterByCountryId = _workContext.CurrentCustomer.BillingAddress.CountryId;
+            }
+
+            var paymentMethodModel = await _checkoutViewModelService.PreparePaymentMethod(cart, filterByCountryId);
+            return paymentMethodModel;
         }
 
         #endregion

--- a/Grand.Web/Models/Checkout/OnePageCheckoutModel.cs
+++ b/Grand.Web/Models/Checkout/OnePageCheckoutModel.cs
@@ -7,6 +7,6 @@ namespace Grand.Web.Models.Checkout
         public bool ShippingRequired { get; set; }
         public bool DisableBillingAddressCheckoutStep { get; set; }
         public CheckoutBillingAddressModel BillingAddress { get; set; }
-
+        public bool HasSinglePaymentMethod { get; set; }
     }
 }

--- a/Grand.Web/Views/Checkout/OnePageCheckout.cshtml
+++ b/Grand.Web/Views/Checkout/OnePageCheckout.cshtml
@@ -173,8 +173,11 @@
                         PaymentInfo.init('#co-payment-info-form', '@(storeLocation)checkout/OpcSavePaymentInfo/');
                 </script>
                 <div class="col-12 buttons pt-1 pb-1 my-3 px-0" id="payment-info-buttons-container">
-                    <a class="btn btn-secondary" href="#" onclick="Checkout.back(); return false;">@T("Common.Back")</a>
-                    <input type="button" class="btn btn-info payment-info-next-step-button" onclick="PaymentInfo.save()" value="@T("Common.Continue")" />
+                    @if (!Model.HasSinglePaymentMethod)
+                    {
+                        <a class="btn btn-secondary" href="#" onclick="Checkout.back();return false;">@T("Common.Back")</a>
+                    }
+                    <input type="button" class="btn btn-info payment-info-next-step-button" onclick="PaymentInfo.save()" value="@T("Common.Continue")"/>
                     <span class="please-wait" id="payment-info-please-wait" style="display: none;">@T("Common.LoadingNextStep")</span>
                 </div>
             </div>


### PR DESCRIPTION
…plication has a single payment method enabled. For single payment the back button of that section will be disabled. Closes #593.

Resolves #593
Type: **bugfix**

## Issue
Payment information was displaying the back button when a single payment method is enabled.

## Solution
Back button will be hidden when single payment method is used.

## Testing
Testing with single payment method
1. Go to admin page and click cofiguration --> Payment --> Payment methods. Setup application to use a single payment method
2. Add items to basket and go to checkout page
3. Payment method should be disabled and payment info should not display back button

Testing with multiple payment methods
1. Go to admin page and click cofiguration --> Payment --> Payment methods. Setup application to use multiple payment methods
2. Add items to basket and go to checkout page
3. Payment method should be enabled and payment info **should** display back button

