### PR TITLE
JWT Token AuthenticationFailed should return 401

### DIFF
--- a/Grand.Api/Infrastructure/ApiAuthenticationRegistrar.cs
+++ b/Grand.Api/Infrastructure/ApiAuthenticationRegistrar.cs
@@ -36,7 +36,7 @@ namespace Grand.Api.Infrastructure
                     OnAuthenticationFailed = context =>
                     {
                         context.NoResult();
-                        context.Response.StatusCode = 500;
+                        context.Response.StatusCode = 401;
                         context.Response.ContentType = "text/plain";
                         context.Response.WriteAsync(context.Exception.Message).Wait();
                         return Task.CompletedTask;


### PR DESCRIPTION
Type: **bugfix**

## Issue
HTTP 500 is internal server error. The client-side app's handles the result with http code.  For example, when the API returns 401 the client app should open the login page on itself.

## Solution
Change http code 500 to 401

## Breaking changes
None

## Testing
Just send invalid token.