### PR TITLE
Add possibility to search in Activity Log by message text #622

### DIFF
--- a/Grand.Services/Logging/CustomerActivityService.cs
+++ b/Grand.Services/Logging/CustomerActivityService.cs
@@ -270,6 +270,7 @@ namespace Grand.Services.Logging
         /// <summary>
         /// Gets all activity log items
         /// </summary>
+        /// <param name="comment">Log item message text or text part; null or empty string to load all</param>
         /// <param name="createdOnFrom">Log item creation from; null to load all customers</param>
         /// <param name="createdOnTo">Log item creation to; null to load all customers</param>
         /// <param name="customerId">Customer identifier; null to load all customers</param>
@@ -277,12 +278,15 @@ namespace Grand.Services.Logging
         /// <param name="pageIndex">Page index</param>
         /// <param name="pageSize">Page size</param>
         /// <returns>Activity log items</returns>
-        public virtual async Task<IPagedList<ActivityLog>> GetAllActivities(DateTime? createdOnFrom = null,
+        public virtual async Task<IPagedList<ActivityLog>> GetAllActivities(string comment = "",
+            DateTime? createdOnFrom = null,
             DateTime? createdOnTo = null, string customerId = "", string activityLogTypeId = "",
             string ipAddress = null,
             int pageIndex = 0, int pageSize = int.MaxValue)
         {
             var query = _activityLogRepository.Table;
+            if (!String.IsNullOrEmpty(comment))
+                query = query.Where(al => al.Comment != null && al.Comment.ToLower().Contains(comment.ToLower()));
             if (createdOnFrom.HasValue)
                 query = query.Where(al => createdOnFrom.Value <= al.CreatedOnUtc);
             if (createdOnTo.HasValue)

--- a/Grand.Services/Logging/ICustomerActivityService.cs
+++ b/Grand.Services/Logging/ICustomerActivityService.cs
@@ -85,6 +85,7 @@ namespace Grand.Services.Logging
         /// <summary>
         /// Gets all activity log items
         /// </summary>
+        /// <param name="comment">Log item message text or text part; null or empty string to load all</param>
         /// <param name="createdOnFrom">Log item creation from; null to load all customers</param>
         /// <param name="createdOnTo">Log item creation to; null to load all customers</param>
         /// <param name="customerId">Customer identifier; null to load all customers</param>
@@ -92,7 +93,8 @@ namespace Grand.Services.Logging
         /// <param name="pageIndex">Page index</param>
         /// <param name="pageSize">Page size</param>
         /// <returns>Activity log items</returns>
-        Task<IPagedList<ActivityLog>> GetAllActivities(DateTime? createdOnFrom = null,
+        Task<IPagedList<ActivityLog>> GetAllActivities(string comment = "",
+            DateTime? createdOnFrom = null,
             DateTime? createdOnTo = null, string customerId = "", string activityLogTypeId = "",
             string ipAddress = null, int pageIndex = 0, int pageSize = int.MaxValue);
 

--- a/Grand.Web/App_Data/Localization/Upgrade/EN_450_460.nopres.xml
+++ b/Grand.Web/App_Data/Localization/Upgrade/EN_450_460.nopres.xml
@@ -353,4 +353,7 @@
   <LocaleResource Name="Admin.ReturnRequests.List.EndDate.Hint">
     <Value>The end date for the search</Value>
   </LocaleResource>
+  <LocaleResource Name="Admin.Configuration.ActivityLog.ActivityLog.Fields.Comment.Hint">
+    <Value>The message text for the search.</Value>
+  </LocaleResource>
 </Language>

--- a/Grand.Web/App_Data/Localization/defaultResources.grandres.xml
+++ b/Grand.Web/App_Data/Localization/defaultResources.grandres.xml
@@ -4776,6 +4776,9 @@
   <LocaleResource Name="Admin.Configuration.ActivityLog.ActivityLog.Fields.Comment">
     <Value>Message</Value>
   </LocaleResource>
+  <LocaleResource Name="Admin.Configuration.ActivityLog.ActivityLog.Fields.Comment.Hint">
+    <Value>The message text for the search.</Value>
+  </LocaleResource>
   <LocaleResource Name="Admin.Configuration.ActivityLog.ActivityLog.Fields.CreatedOn">
     <Value>Created On</Value>
   </LocaleResource>

--- a/Grand.Web/Areas/Admin/Models/Logging/ActivityLogSearchModel.cs
+++ b/Grand.Web/Areas/Admin/Models/Logging/ActivityLogSearchModel.cs
@@ -13,6 +13,10 @@ namespace Grand.Web.Areas.Admin.Models.Logging
         {
             ActivityLogType = new List<SelectListItem>();
         }
+
+        [GrandResourceDisplayName("Admin.Configuration.ActivityLog.ActivityLog.Fields.Comment")]
+        public string Comment { get; set; }
+
         [GrandResourceDisplayName("Admin.Configuration.ActivityLog.ActivityLog.Fields.CreatedOnFrom")]
         [UIHint("DateNullable")]
         public DateTime? CreatedOnFrom { get; set; }

--- a/Grand.Web/Areas/Admin/Services/ActivityLogViewModelService.cs
+++ b/Grand.Web/Areas/Admin/Services/ActivityLogViewModelService.cs
@@ -81,7 +81,7 @@ namespace Grand.Web.Areas.Admin.Services
             DateTime? endDateValue = (model.CreatedOnTo == null) ? null
                             : (DateTime?)_dateTimeHelper.ConvertToUtcTime(model.CreatedOnTo.Value, _dateTimeHelper.CurrentTimeZone).AddDays(1);
 
-            var activityLog = await _customerActivityService.GetAllActivities(startDateValue, endDateValue, null, model.ActivityLogTypeId, model.IpAddress, pageIndex - 1, pageSize);
+            var activityLog = await _customerActivityService.GetAllActivities(model.Comment, startDateValue, endDateValue, null, model.ActivityLogTypeId, model.IpAddress, pageIndex - 1, pageSize);
             var activityLogModel = new List<ActivityLogModel>();
             foreach (var item in activityLog)
             {

--- a/Grand.Web/Areas/Admin/Services/CustomerViewModelService.cs
+++ b/Grand.Web/Areas/Admin/Services/CustomerViewModelService.cs
@@ -1533,7 +1533,7 @@ namespace Grand.Web.Areas.Admin.Services
         }
         public virtual async Task<(IEnumerable<CustomerModel.ActivityLogModel> activityLogModels, int totalCount)> PrepareActivityLogModel(string customerId, int pageIndex, int pageSize)
         {
-            var activityLog = await _customerActivityService.GetAllActivities(null, null, customerId, "", null, pageIndex - 1, pageSize);
+            var activityLog = await _customerActivityService.GetAllActivities(null, null, null, customerId, "", null, pageIndex - 1, pageSize);
             var items = new List<CustomerModel.ActivityLogModel>();
             foreach (var x in activityLog)
             {

--- a/Grand.Web/Areas/Admin/Views/ActivityLog/ListLogs.cshtml
+++ b/Grand.Web/Areas/Admin/Views/ActivityLog/ListLogs.cshtml
@@ -23,6 +23,12 @@
             </div>
             <div class="x_content form">
                 <div class="form-horizontal">
+                    <div class="form-group">
+                        <admin-label asp-for="Comment" />
+                        <div class="col-md-4 col-sm-6">
+                            <admin-input asp-for="Comment" />
+                        </div>
+                    </div>
                     <div class="form-body">
                         <div class="form-group">
                             <admin-label asp-for="CreatedOnFrom" />
@@ -160,10 +166,11 @@
 
     function additionalData() {
         var data = {
+            MessageText: $('#@Html.FieldIdFor(model => model.Comment)').val(),
             CreatedOnFrom: $('#@Html.FieldIdFor(model => model.CreatedOnFrom)').val(),
             CreatedOnTo: $('#@Html.FieldIdFor(model => model.CreatedOnTo)').val(),
             IpAddress: $('#@Html.FieldIdFor(model => model.IpAddress)').val(),
-            ActivityLogTypeId: $('#ActivityLogTypeId').val()
+            ActivityLogTypeId: $('#ActivityLogTypeId').val()          
         };
         addAntiForgeryToken(data);
         return data;

--- a/Grand.Web/Areas/Admin/Views/ActivityLog/ListLogs.cshtml
+++ b/Grand.Web/Areas/Admin/Views/ActivityLog/ListLogs.cshtml
@@ -23,13 +23,13 @@
             </div>
             <div class="x_content form">
                 <div class="form-horizontal">
-                    <div class="form-group">
-                        <admin-label asp-for="Comment" />
-                        <div class="col-md-4 col-sm-6">
-                            <admin-input asp-for="Comment" />
-                        </div>
-                    </div>
                     <div class="form-body">
+                        <div class="form-group">
+                            <admin-label asp-for="Comment" />
+                            <div class="col-md-4 col-sm-6">
+                                <admin-input asp-for="Comment" />
+                            </div>
+                        </div>
                         <div class="form-group">
                             <admin-label asp-for="CreatedOnFrom" />
                             <div class="col-md-4 col-sm-6">
@@ -166,7 +166,7 @@
 
     function additionalData() {
         var data = {
-            MessageText: $('#@Html.FieldIdFor(model => model.Comment)').val(),
+            Comment: $('#@Html.FieldIdFor(model => model.Comment)').val(),
             CreatedOnFrom: $('#@Html.FieldIdFor(model => model.CreatedOnFrom)').val(),
             CreatedOnTo: $('#@Html.FieldIdFor(model => model.CreatedOnTo)').val(),
             IpAddress: $('#@Html.FieldIdFor(model => model.IpAddress)').val(),


### PR DESCRIPTION
Resolves #622 Add possibility to search in Activity Log by message text
Type: feature

## Solution
Added field labeled 'Message' in Admin/ActivityLog/ListLogs search form for non case-sensitive search in the 'Comment' field of activity log entries.