### PR TITLE
Fixed the context in docker-compose for grand.web. Fixes issue #643

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,5 @@ services:
   grand.web:
     image: grand.web
     build:
-      context: ./Grand.Web
+      context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
Resolves #643   
Type: **bugfix**

## Issue
The ```docker-compose up``` command was failing

## Solution
The location of the context was incorrect, because its at the same level as the docker-compose file, its sufficient to just use a ```build: .``` to reference it, as its in the same folder where docker-compose is executed from. https://docs.docker.com/compose/compose-file/#context

## Breaking changes
N/A

## Testing
Remove all previous docker images (by running `docker image rm -f $(docker image ls -q)` (in Windows Powershell))
Re-run ```docker-compose up``` from the root of the repository