### PR TITLE
improve Reorder logic

### DIFF
--- a/Grand.Services/Orders/OrderProcessingService.cs
+++ b/Grand.Services/Orders/OrderProcessingService.cs
@@ -2997,10 +2997,10 @@ namespace Grand.Services.Orders
 
             foreach (var orderItem in order.OrderItems)
             {
-                if (_productService.GetProductById(orderItem.ProductId) != null)
+                var product = await _productService.GetProductById(orderItem.ProductId);
+                if (product != null)
                 {
-                    var product = await _productService.GetProductById(orderItem.ProductId);
-                    if (product != null && product.ProductType == ProductType.SimpleProduct)
+                    if (product.ProductType == ProductType.SimpleProduct)
                     {
                         await _shoppingCartService.AddToCart(customer, orderItem.ProductId,
                             ShoppingCartType.ShoppingCart, order.StoreId, orderItem.WarehouseId,


### PR DESCRIPTION
Resolves Not Applicable
Type: **enhancement**

## Issue
_productService.GetProductById can be just called once. Also it's not `await`, so it will not return null.

## Solution
call GetProductById and check if product object is null

## Breaking changes


## Testing
no additional testing is required
