### PR TITLE
Fixed NullReferenceException

### DIFF
--- a/Grand.Services/Customers/CustomerActionEventService.cs
+++ b/Grand.Services/Customers/CustomerActionEventService.cs
@@ -746,7 +746,7 @@ namespace Grand.Services.Customers
         {
             var actiontypes = await GetAllCustomerActionType();
             var actionType = actiontypes.Where(x => x.SystemKeyword == CustomerActionTypeEnum.AddToCart.ToString()).FirstOrDefault();
-            if (actionType.Enabled)
+            if (actionType?.Enabled == true)
             {
                 var datetimeUtcNow = DateTime.UtcNow;
                 var query = from a in _customerActionRepository.Table
@@ -771,7 +771,7 @@ namespace Grand.Services.Customers
         {
             var actiontypes = await GetAllCustomerActionType();
             var actionType = actiontypes.Where(x => x.SystemKeyword == customerActionType.ToString()).FirstOrDefault();
-            if (actionType.Enabled)
+            if (actionType?.Enabled == true)
             {
                 var datetimeUtcNow = DateTime.UtcNow;
                 var query = from a in _customerActionRepository.Table
@@ -806,7 +806,7 @@ namespace Grand.Services.Customers
             {
                 var actiontypes = await GetAllCustomerActionType();
                 var actionType = actiontypes.Where(x => x.SystemKeyword == CustomerActionTypeEnum.Url.ToString()).FirstOrDefault();
-                if (actionType.Enabled)
+                if (actionType?.Enabled == true)
                 {
                     var datetimeUtcNow = DateTime.UtcNow;
                     var query = from a in _customerActionRepository.Table
@@ -834,7 +834,7 @@ namespace Grand.Services.Customers
             {
                 var actiontypes = await GetAllCustomerActionType();
                 var actionType = actiontypes.Where(x => x.SystemKeyword == CustomerActionTypeEnum.Viewed.ToString()).FirstOrDefault();
-                if (actionType.Enabled)
+                if (actionType?.Enabled == true)
                 {
                     var datetimeUtcNow = DateTime.UtcNow;
                     var query = from a in _customerActionRepository.Table
@@ -861,7 +861,7 @@ namespace Grand.Services.Customers
         {
             var actiontypes = await GetAllCustomerActionType();
             var actionType = actiontypes.Where(x => x.SystemKeyword == CustomerActionTypeEnum.Registration.ToString()).FirstOrDefault();
-            if (actionType.Enabled)
+            if (actionType?.Enabled == true)
             {
                 var datetimeUtcNow = DateTime.UtcNow;
                 var query = from a in _customerActionRepository.Table


### PR DESCRIPTION
In my custom plugin I receive NullReferenceException. I fixed it in this pull request.
As you can see:

```
var actionType = actiontypes.Where(x => x.SystemKeyword == CustomerActionTypeEnum.AddToCart.ToString()).FirstOrDefault();

if (actionType.Enabled)	            if (actionType?.Enabled == true)

```

actionType can be null because FirstOrDefault can return null value (if it not found any elements)