### PR TITLE
DefaultLogger improvements

### DIFF
--- a/Grand.Framework/Infrastructure/DependencyRegistrar.cs
+++ b/Grand.Framework/Infrastructure/DependencyRegistrar.cs
@@ -257,7 +257,7 @@ namespace Grand.Framework.Infrastructure
             builder.RegisterType<TaxCategoryService>().As<ITaxCategoryService>().InstancePerLifetimeScope();
             builder.RegisterType<TaxService>().As<ITaxService>().InstancePerLifetimeScope();
             builder.RegisterType<TaxCategoryService>().As<ITaxCategoryService>().InstancePerLifetimeScope();
-            builder.RegisterType<DefaultLogger>().As<ILogger>().InstancePerLifetimeScope();
+            builder.RegisterType<DefaultLogger>().As<ILogger>().SingleInstance();
             builder.RegisterType<ContactUsService>().As<IContactUsService>().InstancePerLifetimeScope();
             builder.RegisterType<CustomerActivityService>().As<ICustomerActivityService>().InstancePerLifetimeScope();
             builder.RegisterType<ActivityKeywordsProvider>().As<IActivityKeywordsProvider>().InstancePerLifetimeScope();


### PR DESCRIPTION
Resolves 
Type: feature

## Issue
The default logger, logs to Mongo. This despite being implemented as a async task still causes a hang.

## Solution
I made it so that the DefaultLogger, actually polls logs in a `_buffer` and have a async thread dump them into the database at a regular 1sec interval. This offloads the request thread.

## Breaking changes
None

## Testing
1. Do actions that will incur logging and then just watch them pop a sec later on the database
