### PR TITLE
Fixed that PluginDescription of CountryStateZipTaxProvider is null

### DIFF
--- a/Grand.Services/Tax/TaxService.cs
+++ b/Grand.Services/Tax/TaxService.cs
@@ -330,7 +330,7 @@ namespace Grand.Services.Tax
         {
             var descriptor = _pluginFinder.GetPluginDescriptorBySystemName<ITaxProvider>(systemName);
             if (descriptor != null)
-                return descriptor.Instance<ITaxProvider>(_pluginFinder.ServiceProvider);
+                return _serviceProvider.GetRequiredService(descriptor.PluginType) as ITaxProvider;
 
             return null;
         }

--- a/Grand.Services/Tax/TaxService.cs
+++ b/Grand.Services/Tax/TaxService.cs
@@ -290,7 +290,15 @@ namespace Grand.Services.Tax
             {
                 foreach (var error in calculateTaxResult.Errors)
                 {
-                    _logger.Error(string.Format("{0} - {1}", activeTaxProvider.PluginDescriptor.FriendlyName, error), null, customer);
+                    if (activeTaxProvider.PluginDescriptor == null)
+                    {
+                        _logger.Error(string.Format("{0} - {1}", "PluginDescriptor is NULL!!", error), null, customer);
+                    }
+                    else
+                    {
+                        _logger.Error(string.Format("{0} - {1}", activeTaxProvider.PluginDescriptor.FriendlyName, error), null, customer);
+                    }
+
                 }
             }
             return (taxRate, isTaxable);
@@ -322,7 +330,7 @@ namespace Grand.Services.Tax
         {
             var descriptor = _pluginFinder.GetPluginDescriptorBySystemName<ITaxProvider>(systemName);
             if (descriptor != null)
-                return _serviceProvider.GetRequiredService(descriptor.PluginType) as ITaxProvider;
+                return descriptor.Instance<ITaxProvider>(_pluginFinder.ServiceProvider);
 
             return null;
         }

--- a/Tests/Grand.Services.Tests/Tax/TaxServiceTests.cs
+++ b/Tests/Grand.Services.Tests/Tax/TaxServiceTests.cs
@@ -34,8 +34,11 @@ namespace Grand.Services.Tax.Tests
         public void TestInitialize()
         {
             //plugin initialization
-            new Grand.Services.Tests.ServiceTest().PluginInitializator();
-
+            new Services.Tests.ServiceTest().PluginInitializator();
+            var serviceProvider = new Mock<IServiceProvider>();
+            serviceProvider.Setup(x => x.GetRequiredService(typeof(FixedRateTestTaxProvider))).Returns(new FixedRateTestTaxProvider());
+            _serviceProvider = serviceProvider.Object;
+            
             _pluginFinder = new PluginFinder(_serviceProvider);
             _taxSettings = new TaxSettings();
             _taxSettings.ActiveTaxProviderSystemName = "FixedTaxRateTest";
@@ -46,11 +49,7 @@ namespace Grand.Services.Tax.Tests
             _customerSettings = new CustomerSettings();
             _addressSettings = new AddressSettings();
             _logger = new NullLogger();
-            var serviceProvider = new Mock<IServiceProvider>();
-            serviceProvider.Setup(x => x.GetRequiredService(typeof(FixedRateTestTaxProvider))).Returns(new FixedRateTestTaxProvider());
-            _serviceProvider = serviceProvider.Object;
             
-
             _taxService = new TaxService(_addressService, _workContext, _taxSettings,
                 _pluginFinder, _geoLookupService, _countryService, _serviceProvider, _logger,
                 _customerSettings, _addressSettings);

--- a/Tests/Grand.Services.Tests/Tax/TaxServiceTests.cs
+++ b/Tests/Grand.Services.Tests/Tax/TaxServiceTests.cs
@@ -36,7 +36,7 @@ namespace Grand.Services.Tax.Tests
             //plugin initialization
             new Services.Tests.ServiceTest().PluginInitializator();
             var serviceProvider = new Mock<IServiceProvider>();
-            serviceProvider.Setup(x => x.GetRequiredService(typeof(FixedRateTestTaxProvider))).Returns(new FixedRateTestTaxProvider());
+            serviceProvider.Setup(x => x.GetService(typeof(FixedRateTestTaxProvider))).Returns(new FixedRateTestTaxProvider());
             _serviceProvider = serviceProvider.Object;
             
             _pluginFinder = new PluginFinder(_serviceProvider);

--- a/Tests/Grand.Services.Tests/Tax/TaxServiceTests.cs
+++ b/Tests/Grand.Services.Tests/Tax/TaxServiceTests.cs
@@ -47,7 +47,7 @@ namespace Grand.Services.Tax.Tests
             _addressSettings = new AddressSettings();
             _logger = new NullLogger();
             var serviceProvider = new Mock<IServiceProvider>();
-            serviceProvider.Setup(x => x.GetService(typeof(FixedRateTestTaxProvider))).Returns(new FixedRateTestTaxProvider());
+            serviceProvider.Setup(x => x.GetRequiredService(typeof(FixedRateTestTaxProvider))).Returns(new FixedRateTestTaxProvider());
             _serviceProvider = serviceProvider.Object;
             
 


### PR DESCRIPTION
+ Fixed that PluginDescription of CountryStateZipTaxProvider is null
+ Avoid null pointer exception crashing app, when PluginDescription in TaxService is null.

Type: **bugfix**

## Issue 
The app crashed completely when using CountryStateZip Plugin, because when address is not set, the error logging tries to access CountryStateZipTaxProvider.PluginDescriptor.FriendlyName, which is null. 

## Solution
To avoiding that PluginDescriptor is null in TaxService, I replaced the serviceProvider call by instantiating the TaxProvider directly from the descriptor. To avoid in future the same error, I added a null check for PluginDescriptor, and hint in the Logger for the missing PluginDescriptor.
I'm not sure, if this is the right way, but for us it works. Open for improvements.

## Testing / Steps to reproduce
1. Use Country Zip Plugin as Standard Tax method
2. Go to Settings and remove values from taxsettings.defaulttaxaddressid and
taxsettings.defaulttaxcategoryid (in our case it wasn't filled at default state)
3. Restart application (to avoid caching)

*Result before change*:
Internal crash error - Null Reference Exception, app doesn't work anymore

*Result after this change*:
Working application, and an entry in the Log with "Adress is not set"
