### PR TITLE
#582 Notify customer if product is not available for reorder 

### DIFF
--- a/Grand.Services/Commands/Handlers/Orders/ReOrderCommandHandler.cs
+++ b/Grand.Services/Commands/Handlers/Orders/ReOrderCommandHandler.cs
@@ -50,6 +50,10 @@ namespace Grand.Services.Commands.Handlers.Orders
                             orderItem.Quantity, false));
                     }
                 }
+                else
+                {
+                    warnings.Add("Product is not available");
+                }
             }
 
             return warnings;


### PR DESCRIPTION
Resolves #582 
Type: **feature**

## Solution
If the product has been deleted, warning "Product is not available" is shown after redirecting to the empty Cart.
ReOrderCommandHandler - new warning is added in case product is null.

## Testing
1. Make an order with one product
2. Go to the admin tab and delete the product
3. Return to your user's account and click 'Re-order' button on your order from step 1
4. Before fixing - empty card is shown/After fixing - empty card is shown with notification "Product is not available"
