### PR TITLE
#791.blog.categories.counter.doesn't.update.unpublished

### DIFF
--- a/Grand.Services/Blogs/BlogService.cs
+++ b/Grand.Services/Blogs/BlogService.cs
@@ -9,7 +9,9 @@ using MongoDB.Driver.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
 
 namespace Grand.Services.Blogs
 {
@@ -331,17 +333,76 @@ namespace Grand.Services.Blogs
         /// Get all blog categories
         /// </summary>
         /// <returns></returns>
-        public virtual async Task<IList<BlogCategory>> GetAllBlogCategories(string storeId = "")
+        public virtual async Task<IList<BlogCategory>> GetAllBlogCategories(string storeId = "", bool loadOnlyVisiblePosts = true)
+        
         {
+            
+            var visibleBlogPost =(from b in _blogPostRepository.Table
+           where (b.EndDateUtc == null || b.EndDateUtc >= DateTime.Now) && (b.StartDateUtc == null || b.StartDateUtc <= DateTime.Now)
+                                                                            select b).ToList();
+
+            var visibleBlogPostQuery = visibleBlogPost.Select(x => x.Id);
+
+            //var query2 = _blogCategoryRepository.Table.SelectMany(c => new { Cat = c.Name, bologcount = c.BlogPosts.Count(x => visibleBlogPostQuery.Contains(x.BlogPostId)) }
+
+            var query1 = _blogCategoryRepository.Table.Select(c => new {Cat = c.Name,  bologcount = c.BlogPosts.Select(x => x.BlogPostId).Where(x => visibleBlogPostQuery.Contains(x)) })
+                .ToList();
+
+            /*
+
+            var query2 = _blogCategoryRepository.Table.SelectMany(b=>b.BlogPosts.AsQueryable().Select(df => new {Category = b.Name, BlogPostId = df.BlogPostId}))
+                //.Where(x => visibleBlogPostQuery.Contains(x.df.BlogPostId))
+                .ToList();
+            */
+
+            //
+
+            /*var query1 =  (from c in _blogCategoryRepository.Table
+                from p in c.BlogPosts.AsQueryable()
+                where (visibleBlogPostQuery.Contains(p.BlogPostId))
+                select p.BlogPostId).ToList();*/
+
+            //var query1 = _blogCategoryRepository.Table.Select(b=>b.BlogPosts.Select(p=>p.BlogPostId))
+            /*
+                        var query1 = from b in _blogPostRepository.Table
+                            join c in _blogCategoryRepository.Table on b.C*/
+
+
+
             var query = from c in _blogCategoryRepository.Table
-                        select c;
+                select c;
+
+            var result = await query.OrderBy(x => x.DisplayOrder).ToListAsync();
+
+            foreach (var blogCategory in result)
+            {
+                blogCategory.BlogPosts =
+                    blogCategory.BlogPosts.Where(bp => visibleBlogPostQuery.Contains(bp.BlogPostId)).ToList();
+            }
+
+            return result;
 
             if (!String.IsNullOrEmpty(storeId) && !_catalogSettings.IgnoreStoreLimitations)
             {
                 query = query.Where(b => b.Stores.Contains(storeId) || !b.LimitedToStores);
             }
 
-            return await query.OrderBy(x => x.DisplayOrder).ToListAsync();
+            if (loadOnlyVisiblePosts)
+            {
+                
+
+                /*
+                query = query.SelectMany(c => c.BlogPosts)
+                    .Where(bp => visibleBlogPostQuery.Contains(bp.BlogPostId));*/
+
+
+                /*query = query.Where(b => _blogPostRepository.Table
+                    .Where(blogPost => blogPost.EndDateUtc >= DateTime.Now && DateTime.Now >= blogPost.StartDateUtc)
+                    .Select(blogPost => blogPost.Id)
+                    .Contains(b.BlogPosts.SelectMany(bp => bp.BlogPostId)));*/
+            }
+
+            
         }
 
         /// <summary>

--- a/Grand.Services/Blogs/IBlogService.cs
+++ b/Grand.Services/Blogs/IBlogService.cs
@@ -116,7 +116,7 @@ namespace Grand.Services.Blogs
         /// Get all blog categories
         /// </summary>
         /// <returns></returns>
-        Task<IList<BlogCategory>> GetAllBlogCategories(string storeId = "");
+        Task<IList<BlogCategory>> GetAllBlogCategories(string storeId = "", bool loadOnlyVisiblePosts = true);
 
         /// <summary>
         /// Inserts an blog category

--- a/Grand.Web/Areas/Admin/Controllers/BlogController.cs
+++ b/Grand.Web/Areas/Admin/Controllers/BlogController.cs
@@ -218,7 +218,7 @@ namespace Grand.Web.Areas.Admin.Controllers
         [HttpPost]
         public async Task<IActionResult> CategoryList(DataSourceRequest command)
         {
-            var categories = await _blogService.GetAllBlogCategories(_workContext.CurrentCustomer.StaffStoreId);
+            var categories = await _blogService.GetAllBlogCategories(_workContext.CurrentCustomer.StaffStoreId, false);
             var gridModel = new DataSourceResult {
                 Data = categories,
                 Total = categories.Count

--- a/Grand.Web/Features/Handlers/Blogs/GetBlogPostCategoryHandler.cs
+++ b/Grand.Web/Features/Handlers/Blogs/GetBlogPostCategoryHandler.cs
@@ -34,7 +34,7 @@ namespace Grand.Web.Features.Handlers.Blogs
             var cachedModel = await _cacheManager.GetAsync(cacheKey, async () =>
             {
                 var model = new List<BlogPostCategoryModel>();
-                var categories = await _blogService.GetAllBlogCategories(_storeContext.CurrentStore.Id);
+                var categories = await _blogService.GetAllBlogCategories(_storeContext.CurrentStore.Id, true);
                 foreach (var item in categories)
                 {
                     model.Add(new BlogPostCategoryModel() {


### PR DESCRIPTION
Resolves #791 Blog categories counter doesn't update if post is unpublished
Type: **bugfix**

## Solution
Added parameter 'loadOnlyVisiblePosts' to the method GetAllBlogCategories.
In case the parameter is true, all the 'visible' post ids are selected from the database and the result's categorie's posts are filtered using those visible posts.
This case is used in User's UI.

In case the parameter 'loadOnlyVisiblePosts' not set, all the posts ids (future, current, past) are loaded for the categories. 
This case is used in Admin's UI.

