### PR TITLE
#753 Activity log - Make links instead of text in log message

### DIFF
--- a/Grand.Framework/Infrastructure/DependencyRegistrar.cs
+++ b/Grand.Framework/Infrastructure/DependencyRegistrar.cs
@@ -56,6 +56,7 @@ using StackExchange.Redis;
 using System;
 using System.Linq;
 using System.Reflection;
+using Grand.Services.Logging.ActivityLogComment;
 
 namespace Grand.Framework.Infrastructure
 {
@@ -366,6 +367,9 @@ namespace Grand.Framework.Infrastructure
             builder.RegisterType<CustomerActivityService>().As<ICustomerActivityService>().InstancePerLifetimeScope();
             builder.RegisterType<ActivityKeywordsProvider>().As<IActivityKeywordsProvider>().InstancePerLifetimeScope();
             builder.RegisterType<DefaultLogger>().As<ILogger>().InstancePerLifetimeScope();
+            builder.RegisterType<LinkedCommentFormatter>().As<ILinkedCommentFormatter>().InstancePerLifetimeScope();
+            builder.RegisterType<LinkedCommentCreator>().As<ILinkedCommentCreator>().InstancePerLifetimeScope();
+            builder.RegisterType<ActivityEntityKeywordsProvider>().As<IActivityEntityKeywordsProvider>().InstancePerLifetimeScope();
 
         }
         private void RegisterMessageService(ContainerBuilder builder)

--- a/Grand.Services/Logging/ActivityKeywordsProvider.cs
+++ b/Grand.Services/Logging/ActivityKeywordsProvider.cs
@@ -2,60 +2,174 @@
 
 namespace Grand.Services.Logging
 {
-    public class ActivityKeywordsProvider: IActivityKeywordsProvider
+    public class ActivityKeywordsProvider : IActivityKeywordsProvider
     {
         public virtual IList<string> GetCategorySystemKeywords()
         {
-            var tokens = new List<string>
-            {
-                "PublicStore.ViewCategory",
-                "EditCategory",
+            var tokens = new List<string> {
                 "AddNewCategory",
-            };
-            return tokens;
-        }
-        public virtual IList<string> GetProductSystemKeywords()
-        {
-            var tokens = new List<string>
-            {
-                "PublicStore.ViewProduct",
-                "EditProduct",
-                "AddNewProduct",
-            };
-            return tokens;
-        }
-        public virtual IList<string> GetManufacturerSystemKeywords()
-        {
-            var tokens = new List<string>
-            {
-                "PublicStore.ViewManufacturer",
-                "EditManufacturer",
-                "AddNewManufacturer"
+                "EditCategory",
+                "PublicStore.ViewCategory",
             };
             return tokens;
         }
 
-        public IList<string> GetKnowledgebaseCategorySystemKeywords()
+        public virtual IList<string> GetCheckoutAttributeSystemKeywords()
         {
-            var tokens = new List<string>
-            {
-                "CreateKnowledgebaseCategory",
-                "UpdateKnowledgebaseCategory",
-                "DeleteKnowledgebaseCategory"
+            var tokens = new List<string> {
+                "AddNewCheckoutAttribute",
+                "EditCheckoutAttribute",
             };
             return tokens;
         }
 
-
-        public IList<string> GetKnowledgebaseArticleSystemKeywords()
+        public virtual IList<string> GetContactAttributeSystemKeywords()
         {
-            var tokens = new List<string>
-            {
+            var tokens = new List<string> {
+                "AddNewContactAttribute",
+                "EditContactAttribute",
+            };
+            return tokens;
+        }
+
+        public virtual IList<string> GetCustomerSystemKeywords()
+        {
+            var tokens = new List<string> {
+                "AddNewCustomer",
+                "EditCustomer",
+                "CustomerReminder.AbandonedCart",
+                "CustomerReminder.RegisteredCustomer",
+                "CustomerReminder.LastActivity",
+                "CustomerReminder.LastPurchase",
+                "CustomerReminder.Birthday",
+                "CustomerReminder.SendCampaign",
+                "CustomerAdmin.SendEmail",
+                "CustomerAdmin.SendPM",
+            };
+            return tokens;
+        }
+
+        public virtual IList<string> GetCustomerRoleSystemKeywords()
+        {
+            var tokens = new List<string> {
+                "AddNewCustomerRole",
+                "EditCustomerRole",
+            };
+            return tokens;
+        }
+
+        public virtual IList<string> GetDiscountSystemKeywords()
+        {
+            var tokens = new List<string> {
+                "AddNewDiscount",
+                "EditDiscount",
+            };
+            return tokens;
+        }
+
+        public virtual IList<string> GetGiftCardSystemKeywords()
+        {
+            var tokens = new List<string> {
+                "AddNewGiftCard",
+                "EditGiftCard",
+            };
+            return tokens;
+        }
+
+        public virtual IList<string> GetInteractiveFormSystemKeywords()
+        {
+            var tokens = new List<string> {
+                "InteractiveFormEdit",
+                "InteractiveFormAdd",
+                "PublicStore.InteractiveForm",
+            };
+            return tokens;
+        }
+
+        public virtual IList<string> GetKnowledgebaseArticleSystemKeywords()
+        {
+            var tokens = new List<string> {
                 "CreateKnowledgebaseArticle",
                 "UpdateKnowledgebaseArticle",
                 "DeleteKnowledgebaseArticle",
             };
             return tokens;
         }
+
+        public virtual IList<string> GetKnowledgebaseCategorySystemKeywords()
+        {
+            var tokens = new List<string> {
+                "UpdateKnowledgebaseCategory",
+                "CreateKnowledgebaseCategory",
+                "DeleteKnowledgebaseCategory",
+            };
+            return tokens;
+        }
+
+        public virtual IList<string> GetManufacturerSystemKeywords()
+        {
+            var tokens = new List<string> {
+                "AddNewManufacturer",
+                "EditManufacturer",
+                "PublicStore.ViewManufacturer",
+            };
+            return tokens;
+        }
+
+        public virtual IList<string> GetOrderSystemKeywords()
+        {
+            var tokens = new List<string> {
+                "EditOrder",
+                "PublicStore.PlaceOrder",
+            };
+            return tokens;
+        }
+
+        public virtual IList<string> GetProductSystemKeywords()
+        {
+            var tokens = new List<string> {
+                "AddNewProduct",
+                "EditProduct",
+                "PublicStore.ViewProduct",
+            };
+            return tokens;
+        }
+
+        public virtual IList<string> GetProductAttributeSystemKeywords()
+        {
+            var tokens = new List<string> {
+                "AddNewProductAttribute",
+                "EditProductAttribute",
+            };
+            return tokens;
+        }
+
+        public virtual IList<string> GetReturnRequestSystemKeywords()
+        {
+            var tokens = new List<string> {
+                "EditReturnRequest",
+            };
+            return tokens;
+        }
+
+        public virtual IList<string> GetSpecificationAttributeSystemKeywords()
+        {
+            var tokens = new List<string> {
+                "AddNewSpecAttribute",
+                "EditSpecAttribute",
+            };
+            return tokens;
+        }
+
+        public virtual IList<string> GetTopicSystemKeywords()
+        {
+            var tokens = new List<string> {
+                "AddNewTopic",
+                "EditTopic",
+            };
+            return tokens;
+        }
+
+
     }
 }

--- a/Grand.Services/Logging/ActivityLogComment/ActivityEntityKeywordsProvider.cs
+++ b/Grand.Services/Logging/ActivityLogComment/ActivityEntityKeywordsProvider.cs
@@ -1,0 +1,123 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Grand.Services.Logging.ActivityLogComment
+{
+
+    public class ActivityLogEntity
+    {
+        public ActivityLogEntityType EntityType { get; set; }
+
+        public IList<string> EntityKeywords { get; set; }
+
+        public string LinkPattern { get; set; }
+    }
+
+    public class ActivityEntityKeywordsProvider : IActivityEntityKeywordsProvider
+    {
+        private readonly IActivityKeywordsProvider _activityKeywordsProvider;
+        private readonly IList<ActivityLogEntity> _activityEntities;
+
+        public ActivityEntityKeywordsProvider(IActivityKeywordsProvider activityKeywordsProvider)
+        {
+            _activityKeywordsProvider = activityKeywordsProvider;
+            _activityEntities = GetActivityEntities();
+        }
+
+        public ActivityLogEntity GetLogEntity(string activityKeyword)
+        {
+            return _activityEntities.FirstOrDefault(ae => ae.EntityKeywords.Contains(activityKeyword));
+        }
+
+        private IList<ActivityLogEntity> GetActivityEntities()
+        {
+            return new List<ActivityLogEntity> {
+                new ActivityLogEntity {
+                    EntityType = ActivityLogEntityType.Category,
+                    EntityKeywords = _activityKeywordsProvider.GetCategorySystemKeywords(),
+                    LinkPattern = "/Admin/" + ActivityLogEntityType.Category + "/Edit/{0}"
+               },
+                new ActivityLogEntity {
+                    EntityType = ActivityLogEntityType.CheckoutAttribute,
+                    EntityKeywords = _activityKeywordsProvider.GetCheckoutAttributeSystemKeywords(),
+                    LinkPattern = "/Admin/" + ActivityLogEntityType.CheckoutAttribute + "/Edit/{0}"
+               },
+                new ActivityLogEntity {
+                    EntityType = ActivityLogEntityType.ContactAttribute,
+                    EntityKeywords = _activityKeywordsProvider.GetContactAttributeSystemKeywords(),
+                    LinkPattern = "/Admin/" + ActivityLogEntityType.ContactAttribute + "/Edit/{0}"
+               },
+                new ActivityLogEntity {
+                    EntityType = ActivityLogEntityType.Customer,
+                    EntityKeywords = _activityKeywordsProvider.GetCustomerSystemKeywords(),
+                    LinkPattern = "/Admin/" + ActivityLogEntityType.Customer + "/Edit/{0}"
+               },
+                new ActivityLogEntity {
+                    EntityType = ActivityLogEntityType.CustomerRole,
+                    EntityKeywords = _activityKeywordsProvider.GetCustomerRoleSystemKeywords(),
+                    LinkPattern = "/Admin/" + ActivityLogEntityType.CustomerRole + "/Edit/{0}"
+               },
+                new ActivityLogEntity {
+                    EntityType = ActivityLogEntityType.Discount,
+                    EntityKeywords = _activityKeywordsProvider.GetDiscountSystemKeywords(),
+                    LinkPattern = "/Admin/" + ActivityLogEntityType.Discount + "/Edit/{0}"
+               },
+                new ActivityLogEntity {
+                    EntityType = ActivityLogEntityType.GiftCard,
+                    EntityKeywords = _activityKeywordsProvider.GetGiftCardSystemKeywords(),
+                    LinkPattern = "/Admin/" + ActivityLogEntityType.GiftCard + "/Edit/{0}"
+               },
+                new ActivityLogEntity {
+                    EntityType = ActivityLogEntityType.InteractiveForm,
+                    EntityKeywords = _activityKeywordsProvider.GetInteractiveFormSystemKeywords(),
+                    LinkPattern = "/Admin/" + ActivityLogEntityType.InteractiveForm + "/Edit/{0}"
+               },
+                new ActivityLogEntity {
+                    EntityType = ActivityLogEntityType.KnowledgebaseArticle,
+                    EntityKeywords = _activityKeywordsProvider.GetKnowledgebaseArticleSystemKeywords(),
+                    LinkPattern = "/Admin/Knowledgebase/EditArticle/{0}"
+               },
+                new ActivityLogEntity {
+                    EntityType = ActivityLogEntityType.KnowledgebaseCategory,
+                    EntityKeywords = _activityKeywordsProvider.GetKnowledgebaseCategorySystemKeywords(),
+                    LinkPattern = "/Admin/Knowledgebase/EditCategory/{0}"
+               },
+                new ActivityLogEntity {
+                    EntityType = ActivityLogEntityType.Manufacturer,
+                    EntityKeywords = _activityKeywordsProvider.GetManufacturerSystemKeywords(),
+                    LinkPattern = "/Admin/" + ActivityLogEntityType.Manufacturer + "/Edit/{0}"
+               },
+                new ActivityLogEntity {
+                    EntityType = ActivityLogEntityType.Order,
+                    EntityKeywords = _activityKeywordsProvider.GetOrderSystemKeywords(),
+                    LinkPattern = "/Admin/" + ActivityLogEntityType.Order + "/Edit/{0}"
+               },
+                new ActivityLogEntity {
+                    EntityType = ActivityLogEntityType.Product,
+                    EntityKeywords = _activityKeywordsProvider.GetProductSystemKeywords(),
+                    LinkPattern = "/Admin/" + ActivityLogEntityType.Product + "/Edit/{0}"
+               },
+                new ActivityLogEntity {
+                    EntityType = ActivityLogEntityType.ProductAttribute,
+                    EntityKeywords = _activityKeywordsProvider.GetProductAttributeSystemKeywords(),
+                    LinkPattern = "/Admin/" + ActivityLogEntityType.ProductAttribute + "/Edit/{0}"
+               },
+                new ActivityLogEntity {
+                    EntityType = ActivityLogEntityType.ReturnRequest,
+                    EntityKeywords = _activityKeywordsProvider.GetReturnRequestSystemKeywords(),
+                    LinkPattern = "/Admin/ReturnRequestDetails/{0}"
+               },
+                new ActivityLogEntity {
+                    EntityType = ActivityLogEntityType.SpecificationAttribute,
+                    EntityKeywords = _activityKeywordsProvider.GetSpecificationAttributeSystemKeywords(),
+                    LinkPattern = "/Admin/SpecificationAttribute/Edit/{0}"
+               },
+                new ActivityLogEntity {
+                    EntityType = ActivityLogEntityType.Topic,
+                    EntityKeywords = _activityKeywordsProvider.GetTopicSystemKeywords(),
+                    LinkPattern = "/Admin/" + ActivityLogEntityType.Topic + "/Edit/{0}"
+                },
+            };
+        }
+    }
+}

--- a/Grand.Services/Logging/ActivityLogComment/ActivityLogEntityType.cs
+++ b/Grand.Services/Logging/ActivityLogComment/ActivityLogEntityType.cs
@@ -1,0 +1,24 @@
+﻿namespace Grand.Services.Logging.ActivityLogComment
+{
+    public enum ActivityLogEntityType
+    {
+        Unknown,
+        Category,
+        CheckoutAttribute,
+        ContactAttribute,
+        Customer,
+        CustomerRole,
+        Discount,
+        GiftCard,
+        InteractiveForm,
+        KnowledgebaseArticle,
+        KnowledgebaseCategory,
+        Manufacturer,
+        Order,
+        Product,
+        ProductAttribute,
+        ReturnRequest,
+        SpecificationAttribute,
+        Topic,
+    }
+}

--- a/Grand.Services/Logging/ActivityLogComment/IActivityEntityKeywordsProvider.cs
+++ b/Grand.Services/Logging/ActivityLogComment/IActivityEntityKeywordsProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace Grand.Services.Logging.ActivityLogComment
+{
+    public interface IActivityEntityKeywordsProvider
+    {
+        ActivityLogEntity GetLogEntity(string activityKeyword);
+    }
+}

--- a/Grand.Services/Logging/ActivityLogComment/ILinkedCommentCreator.cs
+++ b/Grand.Services/Logging/ActivityLogComment/ILinkedCommentCreator.cs
@@ -1,0 +1,19 @@
+﻿namespace Grand.Services.Logging.ActivityLogComment
+{
+    /// <summary>
+    /// Activity log linked comment creator interface
+    /// </summary>
+    public interface ILinkedCommentCreator
+    {
+        /// <summary>
+        /// Create activity log comment's text, containing hyperlink to the changed object
+        /// </summary>
+        /// <param name="systemKeyword"></param>
+        /// <param name="entityKeyId"></param>
+        /// <param name="commentBase"></param>
+        /// <param name="commentParams"></param>
+        /// <returns></returns>
+        string CreateLinkedComment(string systemKeyword, string entityKeyId,
+            string commentBase, params object[] commentParams);
+    }
+}

--- a/Grand.Services/Logging/ActivityLogComment/ILinkedCommentFormatter.cs
+++ b/Grand.Services/Logging/ActivityLogComment/ILinkedCommentFormatter.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+using Grand.Core.Domain.Logging;
+
+namespace Grand.Services.Logging.ActivityLogComment
+{
+    /// <summary>
+    /// Activity log comment formatter interface
+    /// </summary>
+    public interface ILinkedCommentFormatter
+    {
+        /// <summary>
+        /// Parse activity log comment's plain text and returns comment's text, containing hyperlink to the changed object instead of the object name
+        /// </summary>
+        /// <param name="activityLog"></param>
+        /// <returns></returns>
+        Task<string> AddLinkToPlainComment(ActivityLog activityLog);
+    }
+}

--- a/Grand.Services/Logging/ActivityLogComment/LinkedCommentCreator.cs
+++ b/Grand.Services/Logging/ActivityLogComment/LinkedCommentCreator.cs
@@ -1,0 +1,41 @@
+﻿using System.Linq;
+
+namespace Grand.Services.Logging.ActivityLogComment
+{
+    /// <summary>
+    /// Activity log linked comment creator
+    /// </summary>
+    public class LinkedCommentCreator : ILinkedCommentCreator
+    {
+
+        private readonly IActivityEntityKeywordsProvider _activityEntityKeywords;
+
+        public LinkedCommentCreator(IActivityEntityKeywordsProvider activityEntityKeywords)
+        {
+            _activityEntityKeywords = activityEntityKeywords;
+        }
+
+        /// <summary>
+        /// Create activity log comment's text, containing hyperlink to the changed object
+        /// </summary>
+        /// <param name="systemKeyword"></param>
+        /// <param name="entityKeyId"></param>
+        /// <param name="commentBase"></param>
+        /// <param name="commentParams"></param>
+        /// <returns></returns>
+        public virtual string CreateLinkedComment(string systemKeyword, string entityKeyId,
+            string commentBase, params object[] commentParams)
+        {
+            string plainComment = string.Format(commentBase, commentParams);
+
+            if (commentParams.Length != 1)
+                return plainComment;
+
+            var activityLogEntity = _activityEntityKeywords.GetLogEntity(systemKeyword);
+            if (activityLogEntity == null)
+                return plainComment;
+
+            return LinkedCommentHelper.GenerateLinkedComment(entityKeyId, activityLogEntity.LinkPattern, commentParams.First().ToString(), commentBase);
+        }
+    }
+}

--- a/Grand.Services/Logging/ActivityLogComment/LinkedCommentFormatter.cs
+++ b/Grand.Services/Logging/ActivityLogComment/LinkedCommentFormatter.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Grand.Core.Domain.Logging;
+using Grand.Services.Localization;
+
+namespace Grand.Services.Logging.ActivityLogComment
+{
+    /// <summary>
+    /// Activity log comment formatter
+    /// </summary>
+    public class LinkedCommentFormatter : ILinkedCommentFormatter
+    {
+        private readonly ICustomerActivityService _customerActivityService;
+        private readonly ILocalizationService _localizationService;
+        private readonly IActivityEntityKeywordsProvider _activityEntityKeywords;
+
+        public LinkedCommentFormatter(ICustomerActivityService customerActivityService, 
+            ILocalizationService localizationService, 
+            IActivityEntityKeywordsProvider activityEntityKeywords)
+        {
+            _customerActivityService = customerActivityService;
+            _localizationService = localizationService;
+            _activityEntityKeywords = activityEntityKeywords;
+        }
+
+        /// <summary>
+        /// Parse activity log comment's plain text and returns comment's text, containing hyperlink to the changed object instead of the object name
+        /// </summary>
+        /// <param name="activityLog"></param>
+        /// <returns></returns>
+        public virtual async Task<string> AddLinkToPlainComment(ActivityLog activityLog)
+        {
+            if (CommentAlreadyFormattedWithLinks(activityLog.Comment)) 
+                return activityLog.Comment;
+
+            var activityKeyword = await GetActivityKeyword(activityLog.ActivityLogTypeId);
+            var activityLogEntity = _activityEntityKeywords.GetLogEntity(activityKeyword);
+            if (activityLogEntity == null) 
+                return activityLog.Comment;
+
+            return TryChangeEntityNameToLink(activityLog.EntityKeyId, activityKeyword, activityLog.Comment,
+                activityLogEntity, out string formattedComment) 
+                ? formattedComment 
+                : activityLog.Comment;
+        }
+
+        private bool TryChangeEntityNameToLink(
+            string entityKeyId, 
+            string activityKeyword, 
+            string comment, 
+            ActivityLogEntity activityLogEntity, 
+            out string linkedComment)
+        {
+            var commentBase = _localizationService.GetResource("ActivityLog." + activityKeyword);
+
+            if (!TryParseSingleCommentParameter(comment, commentBase, out string commentParameter))
+            {
+                linkedComment = string.Empty;
+                return false;
+            }
+            
+            linkedComment = LinkedCommentHelper.GenerateLinkedComment(entityKeyId, activityLogEntity.LinkPattern, commentParameter, commentBase);
+
+            return true;
+        }
+
+
+        private async Task<string> GetActivityKeyword(string activityLogTypeId)
+        {
+            var activityType = await _customerActivityService.GetActivityTypeById(activityLogTypeId);
+            return activityType?.SystemKeyword;
+        }
+
+        private static bool CommentAlreadyFormattedWithLinks(string comment)
+        {
+            return comment.Contains("<a", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool TryParseSingleCommentParameter(string comment, string commentBase, out string commentParameter)
+        {
+            string[] logParameters = comment.ParseExact(commentBase);
+
+            //We can change only 1 entity name to the link
+            if (logParameters.Length == 1)
+            {
+                commentParameter = logParameters.First();
+                return true;
+            }
+
+            commentParameter = string.Empty;
+            return false;
+        }
+    }
+}

--- a/Grand.Services/Logging/ActivityLogComment/LinkedCommentHelper.cs
+++ b/Grand.Services/Logging/ActivityLogComment/LinkedCommentHelper.cs
@@ -1,0 +1,12 @@
+﻿namespace Grand.Services.Logging.ActivityLogComment
+{
+    class LinkedCommentHelper
+    {
+        internal static string GenerateLinkedComment(string entityKeyId, string linkPattern, string commentParameter, string commentBase)
+        {
+            var linkUrl = string.Format(linkPattern, entityKeyId); // "/Admin/Category/Edit/5ea45e9c8258183ea0dbcb90"
+            var link = $"<a href=\"{linkUrl}\">{commentParameter}</a>";
+            return string.Format(commentBase, link);
+        }
+    }
+}

--- a/Grand.Services/Logging/ActivityLogComment/StringFormatExtensions.cs
+++ b/Grand.Services/Logging/ActivityLogComment/StringFormatExtensions.cs
@@ -1,0 +1,55 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Grand.Services.Logging.ActivityLogComment
+{
+    /// <summary>
+    /// String format extensions
+    /// </summary>
+    public static class StringFormatExtensions
+    {
+        /// <summary>
+        /// Parse already formatted sting data using pre-defined format
+        /// </summary>
+        /// <param name="data"></param>
+        /// <param name="format"></param>
+        /// <returns></returns>
+        public static string[] ParseExact(this string data, string format)
+        {
+            if (TryParseExact(data, format, out string[] values))
+                return values;
+            else
+                return new string[0];
+        }
+
+        private static bool TryParseExact(
+            this string data,
+            string format,
+            out string[] values)
+        {
+            int tokenCount = 0;
+            format = Regex.Escape(format).Replace("\\{", "{");
+
+            for (tokenCount = 0; ; tokenCount++)
+            {
+                string token = string.Format("{{{0}}}", tokenCount);
+                if (!format.Contains(token)) break;
+                format = format.Replace(token, string.Format("(?'group{0}'.*)", tokenCount));
+            }
+
+            Match match = new Regex(format).Match(data);
+
+            if (tokenCount != (match.Groups.Count - 1))
+            {
+                values = new string[] { };
+                return false;
+            }
+            else
+            {
+                values = new string[tokenCount];
+                for (int index = 0; index < tokenCount; index++)
+                    values[index] = match.Groups[string.Format("group{0}", index)].Value;
+                return true;
+            }
+        }
+    }
+}

--- a/Grand.Services/Logging/CustomerActivityService.cs
+++ b/Grand.Services/Logging/CustomerActivityService.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Grand.Services.Logging.ActivityLogComment;
 
 namespace Grand.Services.Logging
 {
@@ -41,9 +42,11 @@ namespace Grand.Services.Logging
         private readonly IWorkContext _workContext;
         private readonly IWebHelper _webHelper;
         private readonly IActivityKeywordsProvider _activityKeywordsProvider;
+        private readonly ILinkedCommentCreator _linkedCommentCreator;
         #endregion
 
         #region Ctor
+
         /// <summary>
         /// Ctor
         /// </summary>
@@ -53,13 +56,15 @@ namespace Grand.Services.Logging
         /// <param name="workContext">Work context</param>
         /// <param name="webHelper">Web helper</param>
         /// <param name="activityKeywordsProvider">Activity Keywords provider</param>
+        /// <param name="linkedCommentCreator"></param>
         public CustomerActivityService(
             ICacheManager cacheManager,
             IRepository<ActivityLog> activityLogRepository,
             IRepository<ActivityLogType> activityLogTypeRepository,
             IWorkContext workContext,
             IWebHelper webHelper,
-            IActivityKeywordsProvider activityKeywordsProvider)
+            IActivityKeywordsProvider activityKeywordsProvider,
+            ILinkedCommentCreator linkedCommentCreator)
         {
             _cacheManager = cacheManager;
             _activityLogRepository = activityLogRepository;
@@ -67,6 +72,7 @@ namespace Grand.Services.Logging
             _workContext = workContext;
             _webHelper = webHelper;
             _activityKeywordsProvider = activityKeywordsProvider;
+            _linkedCommentCreator = linkedCommentCreator;
         }
 
         #endregion
@@ -211,7 +217,7 @@ namespace Grand.Services.Logging
                 return null;
 
             comment = CommonHelper.EnsureNotNull(comment);
-            comment = string.Format(comment, commentParams);
+            comment = _linkedCommentCreator.CreateLinkedComment(systemKeyword, entityKeyId, comment, commentParams);
             comment = CommonHelper.EnsureMaximumLength(comment, 4000);
 
             var activity = new ActivityLog();

--- a/Grand.Services/Logging/IActivityKeywordsProvider.cs
+++ b/Grand.Services/Logging/IActivityKeywordsProvider.cs
@@ -5,9 +5,21 @@ namespace Grand.Services.Logging
     public partial interface IActivityKeywordsProvider
     {
         IList<string> GetCategorySystemKeywords();
-        IList<string> GetProductSystemKeywords();
-        IList<string> GetManufacturerSystemKeywords();
-        IList<string> GetKnowledgebaseCategorySystemKeywords();
+        IList<string> GetCheckoutAttributeSystemKeywords();
+        IList<string> GetContactAttributeSystemKeywords();
+        IList<string> GetCustomerSystemKeywords();
+        IList<string> GetCustomerRoleSystemKeywords();
+        IList<string> GetDiscountSystemKeywords();
+        IList<string> GetGiftCardSystemKeywords();
+        IList<string> GetInteractiveFormSystemKeywords();
         IList<string> GetKnowledgebaseArticleSystemKeywords();
+        IList<string> GetKnowledgebaseCategorySystemKeywords();
+        IList<string> GetManufacturerSystemKeywords();
+        IList<string> GetOrderSystemKeywords();
+        IList<string> GetProductSystemKeywords();
+        IList<string> GetProductAttributeSystemKeywords();
+        IList<string> GetReturnRequestSystemKeywords();
+        IList<string> GetSpecificationAttributeSystemKeywords();
+        IList<string> GetTopicSystemKeywords();
     }
 }

--- a/Grand.Web/Areas/Admin/Services/CategoryViewModelService.cs
+++ b/Grand.Web/Areas/Admin/Services/CategoryViewModelService.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Grand.Services.Logging.ActivityLogComment;
 
 namespace Grand.Web.Areas.Admin.Services
 {
@@ -41,11 +42,12 @@ namespace Grand.Web.Areas.Admin.Services
         private readonly ILanguageService _languageService;
         private readonly CatalogSettings _catalogSettings;
         private readonly SeoSettings _seoSettings;
+        private readonly ILinkedCommentFormatter _linkedCommentFormatter;
 
         public CategoryViewModelService(ICategoryService categoryService, ICategoryTemplateService categoryTemplateService, IDiscountService discountService,
             ILocalizationService localizationService, IStoreService storeService, ICustomerService customerService, IPictureService pictureService,
             IUrlRecordService urlRecordService, ICustomerActivityService customerActivityService, IProductService productService, IManufacturerService manufacturerService,
-            IVendorService vendorService, IDateTimeHelper dateTimeHelper, ILanguageService languageService, CatalogSettings catalogSettings, SeoSettings seoSettings)
+            IVendorService vendorService, IDateTimeHelper dateTimeHelper, ILanguageService languageService, CatalogSettings catalogSettings, SeoSettings seoSettings, ILinkedCommentFormatter linkedCommentFormatter)
         {
             _categoryService = categoryService;
             _categoryTemplateService = categoryTemplateService;
@@ -63,6 +65,7 @@ namespace Grand.Web.Areas.Admin.Services
             _catalogSettings = catalogSettings;
             _dateTimeHelper = dateTimeHelper;
             _seoSettings = seoSettings;
+            _linkedCommentFormatter = linkedCommentFormatter;
         }
 
         protected virtual async Task PrepareAllCategoriesModel(CategoryModel model, string storeId)
@@ -413,7 +416,7 @@ namespace Grand.Web.Areas.Admin.Services
                 var m = new CategoryModel.ActivityLogModel {
                     Id = item.Id,
                     ActivityLogTypeName = (await _customerActivityService.GetActivityTypeById(item.ActivityLogTypeId))?.Name,
-                    Comment = item.Comment,
+                    Comment =  await _linkedCommentFormatter.AddLinkToPlainComment(item),
                     CreatedOn = _dateTimeHelper.ConvertToUserTime(item.CreatedOnUtc, DateTimeKind.Utc),
                     CustomerId = item.CustomerId,
                     CustomerEmail = customer != null ? customer.Email : "null"

--- a/Grand.Web/Areas/Admin/Services/CustomerViewModelService.cs
+++ b/Grand.Web/Areas/Admin/Services/CustomerViewModelService.cs
@@ -42,6 +42,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using Grand.Services.Logging.ActivityLogComment;
 
 namespace Grand.Web.Areas.Admin.Services
 {
@@ -94,6 +95,7 @@ namespace Grand.Web.Areas.Admin.Services
         private readonly IManufacturerService _manufacturerService;
         private readonly IDownloadService _downloadService;
         private readonly IServiceProvider _serviceProvider;
+        private readonly ILinkedCommentFormatter _linkedCommentFormatter;
 
         public CustomerViewModelService(
             ICustomerService customerService,
@@ -142,7 +144,7 @@ namespace Grand.Web.Areas.Admin.Services
             ICategoryService categoryService,
             IManufacturerService manufacturerService,
             IDownloadService downloadService,
-            IServiceProvider serviceProvider)
+            IServiceProvider serviceProvider, ILinkedCommentFormatter linkedCommentFormatter)
         {
             _customerService = customerService;
             _customerProductService = customerProductService;
@@ -191,6 +193,7 @@ namespace Grand.Web.Areas.Admin.Services
             _manufacturerService = manufacturerService;
             _downloadService = downloadService;
             _serviceProvider = serviceProvider;
+            _linkedCommentFormatter = linkedCommentFormatter;
         }
 
 
@@ -1563,7 +1566,7 @@ namespace Grand.Web.Areas.Admin.Services
                 {
                     Id = x.Id,
                     ActivityLogTypeName = (await _customerActivityService.GetActivityTypeById(x.ActivityLogTypeId))?.Name,
-                    Comment = x.Comment,
+                    Comment = await _linkedCommentFormatter.AddLinkToPlainComment(x),
                     CreatedOn = _dateTimeHelper.ConvertToUserTime(x.CreatedOnUtc, DateTimeKind.Utc),
                     IpAddress = x.IpAddress
                 };

--- a/Grand.Web/Areas/Admin/Services/ManufacturerViewModelService.cs
+++ b/Grand.Web/Areas/Admin/Services/ManufacturerViewModelService.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Grand.Services.Logging.ActivityLogComment;
 
 namespace Grand.Web.Areas.Admin.Services
 {
@@ -44,6 +45,7 @@ namespace Grand.Web.Areas.Admin.Services
         private readonly ILanguageService _languageService;
         private readonly IWorkContext _workContext;
         private readonly SeoSettings _seoSettings;
+        private readonly ILinkedCommentFormatter _linkedCommentFormatter;
 
         #endregion
 
@@ -64,7 +66,7 @@ namespace Grand.Web.Areas.Admin.Services
             IDateTimeHelper dateTimeHelper,
             ILanguageService languageService,
             IWorkContext workContext,
-            SeoSettings seoSettings)
+            SeoSettings seoSettings, ILinkedCommentFormatter linkedCommentFormatter)
         {
             _categoryService = categoryService;
             _manufacturerTemplateService = manufacturerTemplateService;
@@ -82,6 +84,7 @@ namespace Grand.Web.Areas.Admin.Services
             _languageService = languageService;
             _workContext = workContext;
             _seoSettings = seoSettings;
+            _linkedCommentFormatter = linkedCommentFormatter;
         }
 
         #endregion
@@ -327,7 +330,7 @@ namespace Grand.Web.Areas.Admin.Services
                 {
                     Id = x.Id,
                     ActivityLogTypeName = (await _customerActivityService.GetActivityTypeById(x.ActivityLogTypeId))?.Name,
-                    Comment = x.Comment,
+                    Comment = await _linkedCommentFormatter.AddLinkToPlainComment(x),
                     CreatedOn = _dateTimeHelper.ConvertToUserTime(x.CreatedOnUtc, DateTimeKind.Utc),
                     CustomerId = x.CustomerId,
                     CustomerEmail = customer != null ? customer.Email : "null"

--- a/Grand.Web/Areas/Admin/Services/ProductViewModelService.cs
+++ b/Grand.Web/Areas/Admin/Services/ProductViewModelService.cs
@@ -34,6 +34,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Grand.Services.Logging.ActivityLogComment;
 
 namespace Grand.Web.Areas.Admin.Services
 {
@@ -71,6 +72,7 @@ namespace Grand.Web.Areas.Admin.Services
         private readonly CurrencySettings _currencySettings;
         private readonly MeasureSettings _measureSettings;
         private readonly TaxSettings _taxSettings;
+        private readonly ILinkedCommentFormatter _linkedCommentFormatter;
 
         public ProductViewModelService(
                IProductService productService,
@@ -103,7 +105,7 @@ namespace Grand.Web.Areas.Admin.Services
                IServiceProvider serviceProvider,
                CurrencySettings currencySettings,
                MeasureSettings measureSettings,
-               TaxSettings taxSettings)
+               TaxSettings taxSettings, ILinkedCommentFormatter linkedCommentFormatter)
         {
             _productService = productService;
             _pictureService = pictureService;
@@ -136,6 +138,7 @@ namespace Grand.Web.Areas.Admin.Services
             _currencySettings = currencySettings;
             _measureSettings = measureSettings;
             _taxSettings = taxSettings;
+            _linkedCommentFormatter = linkedCommentFormatter;
         }
         protected virtual async Task UpdatePictureSeoNames(Product product)
         {
@@ -2081,7 +2084,7 @@ namespace Grand.Web.Areas.Admin.Services
                 new ProductModel.ActivityLogModel {
                     Id = x.Id,
                     ActivityLogTypeName = (await _customerActivityService.GetActivityTypeById(x.ActivityLogTypeId))?.Name,
-                    Comment = x.Comment,
+                    Comment = await _linkedCommentFormatter.AddLinkToPlainComment(x),
                     CreatedOn = _dateTimeHelper.ConvertToUserTime(x.CreatedOnUtc, DateTimeKind.Utc),
                     CustomerId = x.CustomerId,
                     CustomerEmail = customer != null ? customer.Email : "null"

--- a/Grand.Web/Areas/Admin/Views/ActivityLog/ListLogs.cshtml
+++ b/Grand.Web/Areas/Admin/Views/ActivityLog/ListLogs.cshtml
@@ -136,8 +136,9 @@
                 field: "IpAddress",
                 title: "@T("Admin.Configuration.ActivityLog.ActivityLog.Fields.IpAddress")"
             }, {
-                field: "Comment",
-                title: "@T("Admin.Configuration.ActivityLog.ActivityLog.Fields.Comment")"
+                    field: "Comment",
+                    title: "@T("Admin.Configuration.ActivityLog.ActivityLog.Fields.Comment")",
+                    encoded: false
             }, {
                 field: "CreatedOn",
                 title: "@T("Admin.System.Log.Fields.CreatedOn")",

--- a/Grand.Web/Areas/Admin/Views/Category/_CreateOrUpdate.TabActivityLog.cshtml
+++ b/Grand.Web/Areas/Admin/Views/Category/_CreateOrUpdate.TabActivityLog.cshtml
@@ -56,7 +56,8 @@
                 }, {
                     field: "Comment",
                     minScreenWidth: 750,
-                    title: "@T("Admin.Catalog.Categories.ActivityLog.Comment")"
+                    title: "@T("Admin.Catalog.Categories.ActivityLog.Comment")",
+                    encoded: false
                 }, {
                     field: "CreatedOn",
                     title: "@T("Admin.Catalog.Categories.ActivityLog.CreatedOn")",

--- a/Grand.Web/Areas/Admin/Views/Customer/_CreateOrUpdate.TabActivityLog.cshtml
+++ b/Grand.Web/Areas/Admin/Views/Customer/_CreateOrUpdate.TabActivityLog.cshtml
@@ -57,6 +57,7 @@
                     field: "Comment",
                     title: "@T("Admin.Customers.Customers.ActivityLog.Comment")",
                     width: 250,
+                    encoded: false
                 }, {
                     field: "CreatedOn",
                     title: "@T("Admin.Customers.Customers.ActivityLog.CreatedOn")",

--- a/Grand.Web/Areas/Admin/Views/Manufacturer/_CreateOrUpdate.TabActivityLog.cshtml
+++ b/Grand.Web/Areas/Admin/Views/Manufacturer/_CreateOrUpdate.TabActivityLog.cshtml
@@ -57,6 +57,7 @@
                     field: "Comment",
                     title: "@T("Admin.Catalog.Manufacturers.ActivityLog.Comment")",
                     minScreenWidth: 750,
+                    encoded: false
                 }, {
                     field: "CreatedOn",
                     title: "@T("Admin.Catalog.Manufacturers.ActivityLog.CreatedOn")",

--- a/Grand.Web/Areas/Admin/Views/Product/_CreateOrUpdate.Activitylog.cshtml
+++ b/Grand.Web/Areas/Admin/Views/Product/_CreateOrUpdate.Activitylog.cshtml
@@ -59,6 +59,7 @@
                     field: "Comment",
                     title: "@T("Admin.Catalog.Products.ActivityLog.Comment")",
                     minScreenWidth: 750,
+                    encoded: false
                 }, {
                     field: "CreatedOn",
                     title: "@T("Admin.Catalog.Products.ActivityLog.CreatedOn")",

--- a/Grand.Web/web.config
+++ b/Grand.Web/web.config
@@ -4,7 +4,7 @@
     <handlers>
       <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
     </handlers>
-    <aspNetCore requestTimeout="23:00:00" processPath="%LAUNCHER_PATH%" forwardWindowsAuthToken="false" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" startupTimeLimit="3600" hostingModel="InProcess" arguments="%LAUNCHER_ARGS%">
+    <aspNetCore requestTimeout="23:00:00" processPath="%LAUNCHER_PATH%" forwardWindowsAuthToken="false" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" startupTimeLimit="3600" hostingModel="InProcess">
       <environmentVariables>
         <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Development" />
         <environmentVariable name="COMPLUS_ForceENC" value="1" />

--- a/Grand.Web/web.config
+++ b/Grand.Web/web.config
@@ -4,7 +4,7 @@
     <handlers>
       <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
     </handlers>
-    <aspNetCore requestTimeout="23:00:00" processPath="%LAUNCHER_PATH%" forwardWindowsAuthToken="false" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" startupTimeLimit="3600" hostingModel="InProcess">
+    <aspNetCore requestTimeout="23:00:00" processPath="%LAUNCHER_PATH%" forwardWindowsAuthToken="false" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" startupTimeLimit="3600" hostingModel="InProcess" arguments="%LAUNCHER_ARGS%">
       <environmentVariables>
         <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Development" />
         <environmentVariable name="COMPLUS_ForceENC" value="1" />

--- a/Tests/Grand.Services.Tests/Logging/CustomerActivityServiceMock.cs
+++ b/Tests/Grand.Services.Tests/Logging/CustomerActivityServiceMock.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Grand.Core.Domain.Logging;
+using Grand.Services.Logging;
+using Moq;
+
+namespace Grand.Services.Tests.Logging
+{
+    class CustomerActivityServiceMock : Mock<ICustomerActivityService>
+    {
+        public CustomerActivityServiceMock()
+        {
+            Setup(o => o.GetActivityTypeById(It.IsAny<string>()))
+                .Returns<string>(a => Task.Run(() => ActivityTypes[a]));
+        }
+
+        private static Dictionary<string, ActivityLogType> ActivityTypes =>
+            new Dictionary<string, ActivityLogType>
+            {
+                {"5ea45e9c8258183ea0dbcaf1", new ActivityLogType {SystemKeyword = "AddNewCategory"} },
+                {"5ea45e9c8258183ea0dbcaf2", new ActivityLogType {SystemKeyword = "AddNewCheckoutAttribute"} },
+                {"5ea45e9c8258183ea0dbcaf3", new ActivityLogType {SystemKeyword = "AddNewContactAttribute"} },
+                {"5ea45e9c8258183ea0dbcaf4", new ActivityLogType {SystemKeyword = "AddNewCustomer"} },
+                {"5ea45e9c8258183ea0dbcaf5", new ActivityLogType {SystemKeyword = "AddNewCustomerRole"} },
+                {"5ea45e9c8258183ea0dbcaf6", new ActivityLogType {SystemKeyword = "AddNewDiscount"} },
+                {"5ea45e9c8258183ea0dbcaf9", new ActivityLogType {SystemKeyword = "AddNewGiftCard"} },
+                {"5ea45e9c8258183ea0dbcb27", new ActivityLogType {SystemKeyword = "InteractiveFormEdit"} },
+                {"5ea45e9c8258183ea0dbcb51", new ActivityLogType {SystemKeyword = "CreateKnowledgebaseArticle"} },
+                {"5ea45e9c8258183ea0dbcb4e", new ActivityLogType {SystemKeyword = "UpdateKnowledgebaseCategory"} },
+                {"5ea45e9c8258183ea0dbcafa", new ActivityLogType {SystemKeyword = "AddNewManufacturer"} },
+                {"5ea45e9c8258183ea0dbcb1e", new ActivityLogType {SystemKeyword = "EditOrder"} },
+                {"5ea45e9c8258183ea0dbcafb", new ActivityLogType {SystemKeyword = "AddNewProduct"} },
+                {"5ea45e9c8258183ea0dbcafc", new ActivityLogType {SystemKeyword = "AddNewProductAttribute"} },
+                {"5ea45e9c8258183ea0dbcb22", new ActivityLogType {SystemKeyword = "EditReturnRequest"} },
+                {"5ea45e9c8258183ea0dbcafe", new ActivityLogType {SystemKeyword = "AddNewSpecAttribute"} },
+                {"5ea45e9c8258183ea0dbcaff", new ActivityLogType {SystemKeyword = "AddNewTopic"} },
+                {"5ea45e9c8258183ea0dbcb4c", new ActivityLogType {SystemKeyword = "SendEmailFromAdminPanel"} },
+                {"5ea45e9c8258183ea0dbcb25", new ActivityLogType {SystemKeyword = "EditTopic"} },
+                {"5ea45e9c8258183ea0dbcb0d", new ActivityLogType {SystemKeyword = "DeleteProduct"} },
+                {"5ea45e9c8258183ea0dbcb28", new ActivityLogType {SystemKeyword = "InteractiveFormAdd"} },
+                {"5ea45e9c8258183ea0dbcb23", new ActivityLogType {SystemKeyword = "EditSettings"} },
+                {"5ea45e9c8258183ea0dbcb24", new ActivityLogType {SystemKeyword = "EditSpecAttribute"} },
+                {"5ea45e9c8258183ea0dbcb4f", new ActivityLogType {SystemKeyword = "CreateKnowledgebaseCategory"} },
+                {"5ea45e9c8258183ea0dbcb1f", new ActivityLogType {SystemKeyword = "EditProduct"} },
+                {"5ea45e9c8258183ea0dbcb14", new ActivityLogType {SystemKeyword = "EditCategory"} },
+                {"5ea45e9c8258183ea0dbcb1d", new ActivityLogType {SystemKeyword = "EditManufacturer"} },
+                {"5ea45e9c8258183ea0dbcb20", new ActivityLogType {SystemKeyword = "EditProductAttribute"} }
+            };
+    }
+}

--- a/Tests/Grand.Services.Tests/Logging/LinkedCommentCreatorTests.cs
+++ b/Tests/Grand.Services.Tests/Logging/LinkedCommentCreatorTests.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections.Generic;
+using Grand.Services.Logging;
+using Grand.Services.Logging.ActivityLogComment;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Grand.Services.Tests.Logging
+{
+    
+    [TestClass()]
+    public class LinkedCommentCreatorTests
+    {
+        private ILinkedCommentCreator _linkedCommentFormatter;
+
+        [TestInitialize()]
+        public void TestInitialize()
+        {
+            IActivityKeywordsProvider activityKeywordsProvider = new ActivityKeywordsProvider();
+            IActivityEntityKeywordsProvider activityEntityKeywords = new ActivityEntityKeywordsProvider(activityKeywordsProvider);
+            _linkedCommentFormatter = new LinkedCommentCreator(activityEntityKeywords);
+        }
+
+        [TestMethod]
+        public void IfNoParameters_PlainTextShouldBeReturned()
+        {
+            var expected = "Edited settings";
+
+            string result = _linkedCommentFormatter.CreateLinkedComment("EditSettings", "", "Edited settings", new object[0]);
+            Assert.AreEqual(expected, result);
+        }
+
+        public static IEnumerable<object[]> NotSupportedByFormatterActivityKeywords()
+        {
+            yield return new object[] {
+                "SendEmailFromAdminPanel",
+                "5ea45e9c8258183ea0dbcb4c",
+                "Email (from admin panel) {0}",
+                new object[] {"antigoniapower@gmail.com"},
+                "Email (from admin panel) antigoniapower@gmail.com",
+
+            };
+            yield return new object[] {
+                "DeleteProduct",
+                "5ea45e9c8258183ea0dbcb4c",
+                "Deleted a product ('{0}')",
+                new object[] { "Elegant Gemstone Necklace" },
+                "Deleted a product ('Elegant Gemstone Necklace')",
+            };
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(NotSupportedByFormatterActivityKeywords), DynamicDataSourceType.Method)]
+        public void IfSystemKeywordNotSupported_PlainTextShouldBeReturned(string systemKeyword, string entityKeyId,
+            string commentBase, object[] commentParams, string expected)
+        {
+            string result = _linkedCommentFormatter.CreateLinkedComment(systemKeyword, entityKeyId, commentBase, commentParams);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        public static IEnumerable<object[]> SupportedByFormatterActivityKeywords()
+        {
+            yield return new object[] {
+                "AddNewSpecAttribute",
+                "5eb8351c92301e734412a1b6",
+                "Added a new specification attribute ('{0}')",
+                new []{ "Nikola" },
+                "Added a new specification attribute ('<a href=\"/Admin/SpecificationAttribute/Edit/5eb8351c92301e734412a1b6\">Nikola</a>')",
+                
+            };
+            yield return new object[] {
+                "EditProduct",
+                "5ea45e9d8258183ea0dbcd1e",
+                "Edited a product ('{0}')",
+                new [] { "Apple iCam" },
+                "Edited a product ('<a href=\"/Admin/Product/Edit/5ea45e9d8258183ea0dbcd1e\">Apple iCam</a>')",
+            };
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(SupportedByFormatterActivityKeywords), DynamicDataSourceType.Method)]
+        public void IfSystemKeywordSupported_TextWithLinkShouldBeReturned(string systemKeyword, string entityKeyId,
+            string commentBase, object[] commentParams, string expected)
+        {
+            string result = _linkedCommentFormatter.CreateLinkedComment(systemKeyword, entityKeyId, commentBase, commentParams);
+
+            Assert.AreEqual(expected, result);
+        }
+    }
+}

--- a/Tests/Grand.Services.Tests/Logging/LinkedCommentFormatterTests.cs
+++ b/Tests/Grand.Services.Tests/Logging/LinkedCommentFormatterTests.cs
@@ -1,0 +1,224 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Grand.Core.Domain.Logging;
+using Grand.Services.Localization;
+using Grand.Services.Logging;
+using Grand.Services.Logging.ActivityLogComment;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Grand.Services.Tests.Logging
+{
+    [TestClass()]
+    public class LinkedCommentFormatterTests
+    {
+        private ILinkedCommentFormatter _linkedCommentFormatter;
+
+        [TestInitialize()]
+        public void TestInitialize()
+        {
+            ICustomerActivityService customerActivityService = new CustomerActivityServiceMock().Object;
+            ILocalizationService localizationService = new LocalizationServiceMock().Object;
+            IActivityKeywordsProvider activityKeywordsProvider = new ActivityKeywordsProvider();
+            IActivityEntityKeywordsProvider activityEntityKeywords = new ActivityEntityKeywordsProvider(activityKeywordsProvider);
+            _linkedCommentFormatter = new LinkedCommentFormatter(customerActivityService, localizationService, activityEntityKeywords);
+        }
+
+        [TestMethod]
+        public async Task AlreadyFormattedComment_ShouldNotBeChanged()
+        {
+            var activityLog = new ActivityLog {
+                ActivityLogTypeId = "5ea45e9c8258183ea0dbcb25",
+                EntityKeyId = "5ea45e888258183ea0dbaf23",
+                Comment = "Edited a topic ('<a href=\"/Admin/Topic/Edit/5ea45e888258183ea0dbaf23\">ApplyVendor</a>')"
+            };
+            var expected = "Edited a topic ('<a href=\"/Admin/Topic/Edit/5ea45e888258183ea0dbaf23\">ApplyVendor</a>')";
+
+            string result = await _linkedCommentFormatter.AddLinkToPlainComment(activityLog);
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public async Task CommentWithoutParameter_ShouldNotBeChanged()
+        {
+            var activityLog = new ActivityLog {
+                ActivityLogTypeId = "5ea45e9c8258183ea0dbcb23",
+                EntityKeyId = "",
+                Comment = "Edited settings"
+            };
+            var expected = "Edited settings";
+
+            string result = await _linkedCommentFormatter.AddLinkToPlainComment(activityLog);
+            Assert.AreEqual(expected, result);
+        }
+
+        public static IEnumerable<object[]> NotSupportedByFormatterActivityKeywordLogs()
+        {
+            yield return new object[] {
+                new ActivityLog {
+                    ActivityLogTypeId = "5ea45e9c8258183ea0dbcb4c",
+                    EntityKeyId = "",
+                    Comment = "Email (from admin panel) antigoniapower@gmail.com"
+                },
+                "Email (from admin panel) antigoniapower@gmail.com"
+            };
+            yield return new object[] {
+                new ActivityLog {
+                    ActivityLogTypeId = "5ea45e9c8258183ea0dbcb0d",
+                    EntityKeyId = "5ea45e9e8258183ea0dbcdfa",
+                    Comment = "Deleted a product ('Elegant Gemstone Necklace')"
+                },
+                "Deleted a product ('Elegant Gemstone Necklace')"
+            };
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(NotSupportedByFormatterActivityKeywordLogs), DynamicDataSourceType.Method)]
+        public async Task NotSupportedByFormatterActivityKeywordLogs_ShouldNotBeChanged(ActivityLog activityLog, string expected)
+        {
+            string result = await _linkedCommentFormatter.AddLinkToPlainComment(activityLog);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        public static IEnumerable<object[]> NotFormattedActivityLogs()
+        {
+            yield return new object[] {
+                new ActivityLog {
+                    ActivityLogTypeId = "5ea45e9c8258183ea0dbcb1e",
+                    EntityKeyId = "5eb80fbcca703c733490b2c7",
+                    Comment = "Edited an order (ID = 5eb80fbcca703c733490b2c7). See order notes for details"
+                },
+                "Edited an order (ID = <a href=\"/Admin/Order/Edit/5eb80fbcca703c733490b2c7\">5eb80fbcca703c733490b2c7</a>). See order notes for details"
+            };
+            yield return new object[] {
+                new ActivityLog {
+                    ActivityLogTypeId = "5ea45e9c8258183ea0dbcafe",
+                    EntityKeyId = "5eb8351c92301e734412a1b6",
+                    Comment = "Added a new specification attribute ('Nikola')"
+                },
+                "Added a new specification attribute ('<a href=\"/Admin/SpecificationAttribute/Edit/5eb8351c92301e734412a1b6\">Nikola</a>')"
+            };
+            yield return new object[] {
+                new ActivityLog {
+                    ActivityLogTypeId = "5ea45e9c8258183ea0dbcb24",
+                    EntityKeyId = "5eb8351c92301e734412a1b6",
+                    Comment = "Edited a specification attribute ('Nikola')"
+                },
+                "Edited a specification attribute ('<a href=\"/Admin/SpecificationAttribute/Edit/5eb8351c92301e734412a1b6\">Nikola</a>')"
+            };
+            yield return new object[] {
+                new ActivityLog {
+                    ActivityLogTypeId = "5ea45e9c8258183ea0dbcb1f",
+                    EntityKeyId = "5ea45e9d8258183ea0dbcd1e",
+                    Comment = "Edited a product ('Apple iCam')"
+                },
+                "Edited a product ('<a href=\"/Admin/Product/Edit/5ea45e9d8258183ea0dbcd1e\">Apple iCam</a>')"
+            };
+            yield return new object[] {
+                new ActivityLog {
+                    ActivityLogTypeId = "5ea45e9c8258183ea0dbcb0d",
+                    EntityKeyId = "5ea45e9e8258183ea0dbcdfa",
+                    Comment = "Deleted a product ('Elegant Gemstone Necklace')"
+                },
+                "Deleted a product ('Elegant Gemstone Necklace')"
+            };
+            yield return new object[] {
+                new ActivityLog {
+                    ActivityLogTypeId = "5ea45e9c8258183ea0dbcb14",
+                    EntityKeyId = "5ea45e9c8258183ea0dbcb90",
+                    Comment = "Edited a category ('Computers')"
+                },
+                "Edited a category ('<a href=\"/Admin/Category/Edit/5ea45e9c8258183ea0dbcb90\">Computers</a>')"
+            };
+            yield return new object[] {
+                new ActivityLog {
+                    ActivityLogTypeId = "5ea45e9c8258183ea0dbcb1d",
+                    EntityKeyId = "5ea45e9d8258183ea0dbcbc5",
+                    Comment = "Edited a manufacturer ('Nike')"
+                },
+                "Edited a manufacturer ('<a href=\"/Admin/Manufacturer/Edit/5ea45e9d8258183ea0dbcbc5\">Nike</a>')"
+            };
+            yield return new object[] {
+                new ActivityLog {
+                    ActivityLogTypeId = "5ea45e9c8258183ea0dbcb4f",
+                    EntityKeyId = "5ec6a29f57c49f52cc14450e",
+                    Comment = "Created knowledgebase category ('Test Category')"
+                },
+                "Created knowledgebase category ('<a href=\"/Admin/Knowledgebase/EditCategory/5ec6a29f57c49f52cc14450e\">Test Category</a>')"
+            };
+            yield return new object[] {
+                new ActivityLog {
+                    ActivityLogTypeId = "5ea45e9c8258183ea0dbcb51",
+                    EntityKeyId = "5ec6a2cf57c49f52cc14456a",
+                    Comment = "Created knowledgebase article ('sdfsdf')"
+                },
+                "Created knowledgebase article ('<a href=\"/Admin/Knowledgebase/EditArticle/5ec6a2cf57c49f52cc14456a\">sdfsdf</a>')"
+            };
+            yield return new object[] {
+                new ActivityLog {
+                    ActivityLogTypeId = "5ea45e9c8258183ea0dbcaf3",
+                    EntityKeyId = "5ec7f9ccdb062b73a4834c3d",
+                    Comment = "Added a new contact attribute ('ContactAttributeTest')"
+                },
+                "Added a new contact attribute ('<a href=\"/Admin/ContactAttribute/Edit/5ec7f9ccdb062b73a4834c3d\">ContactAttributeTest</a>')"
+            };
+            yield return new object[] {
+                new ActivityLog {
+                    ActivityLogTypeId = "5ea45e9c8258183ea0dbcaf5",
+                    EntityKeyId = "5ec7fbf3db062b73a483511a",
+                    Comment = "Added a new customer role ('TestRole')"
+                },
+                "Added a new customer role ('<a href=\"/Admin/CustomerRole/Edit/5ec7fbf3db062b73a483511a\">TestRole</a>')"
+            };
+            yield return new object[] {
+                new ActivityLog {
+                    ActivityLogTypeId = "5ea45e9c8258183ea0dbcaf6",
+                    EntityKeyId = "5ec7fc7cdb062b73a4835160",
+                    Comment = "Added a new discount ('TestDiscount')"
+                },
+                "Added a new discount ('<a href=\"/Admin/Discount/Edit/5ec7fc7cdb062b73a4835160\">TestDiscount</a>')"
+            };
+            yield return new object[] {
+                new ActivityLog {
+                    ActivityLogTypeId = "5ea45e9c8258183ea0dbcaf9",
+                    EntityKeyId = "5ec7fcc2db062b73a483549d",
+                    Comment = "Added a new gift card ('a1ebf57e-f18b')"
+                },
+                "Added a new gift card ('<a href=\"/Admin/GiftCard/Edit/5ec7fcc2db062b73a483549d\">a1ebf57e-f18b</a>')"
+            };
+            yield return new object[] {
+                new ActivityLog {
+                    ActivityLogTypeId = "5ea45e9c8258183ea0dbcb28",
+                    EntityKeyId = "5ec7fd03db062b73a48355db",
+                    Comment = "Add Interactive form - TestInteractiveForm"
+                },
+                "Add Interactive form - <a href=\"/Admin/InteractiveForm/Edit/5ec7fd03db062b73a48355db\">TestInteractiveForm</a>"
+            };
+            yield return new object[] {
+                new ActivityLog {
+                    ActivityLogTypeId = "5ea45e9c8258183ea0dbcb20",
+                    EntityKeyId = "5ea45e9c8258183ea0dbcb8d",
+                    Comment = "Edited a product attribute ('Size')"
+                },
+                "Edited a product attribute ('<a href=\"/Admin/ProductAttribute/Edit/5ea45e9c8258183ea0dbcb8d\">Size</a>')"
+            };
+            yield return new object[] {
+                new ActivityLog {
+                    ActivityLogTypeId = "5ea45e9c8258183ea0dbcb25",
+                    EntityKeyId = "5ea45e888258183ea0dbaf23",
+                    Comment = "Edited a topic ('ApplyVendor')"
+                },
+                "Edited a topic ('<a href=\"/Admin/Topic/Edit/5ea45e888258183ea0dbaf23\">ApplyVendor</a>')"
+            };
+        }
+        
+        [DataTestMethod]
+        [DynamicData(nameof(NotFormattedActivityLogs), DynamicDataSourceType.Method)]
+        public async Task NotFormattedComment_ShouldBeFormattedWitLink(ActivityLog activityLog, string expected)
+        {
+            string result = await _linkedCommentFormatter.AddLinkToPlainComment(activityLog);
+
+            Assert.AreEqual(expected, result);
+        }
+    }
+}

--- a/Tests/Grand.Services.Tests/Logging/LocalizationServiceMock.cs
+++ b/Tests/Grand.Services.Tests/Logging/LocalizationServiceMock.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using Grand.Services.Localization;
+using Moq;
+
+namespace Grand.Services.Tests.Logging
+{
+    class LocalizationServiceMock : Mock<ILocalizationService>
+    {
+        public LocalizationServiceMock()
+        {
+            Setup(o => o.GetResource(It.IsAny<string>()))
+                .Returns<string>(a => Localizations[a.ToLower()]);
+        }
+
+        private static Dictionary<string, string> Localizations =>
+            new Dictionary<string, string>
+            {
+                {"activitylog.addnewcategory", "Added a new category ('{0}')"},
+                {"activitylog.addnewcheckoutattribute", "Added a new checkout attribute ('{0}')"},
+                {"activitylog.addnewcontactattribute", "Added a new contact attribute ('{0}')"},
+                {"activitylog.addnewcustomer", "Added a new customer (ID = {0})"},
+                {"activitylog.addnewcustomerrole", "Added a new customer role ('{0}')"},
+                {"activitylog.addnewdiscount", "Added a new discount ('{0}')"},
+                {"activitylog.addnewgiftcard", "Added a new gift card ('{0}')"},
+                {"activitylog.addnewmanufacturer", "Added a new manufacturer ('{0}')"},
+                {"activitylog.addnewproduct", "Added a new product ('{0}')"},
+                {"activitylog.addnewproductattribute", "Added a new product attribute ('{0}')"},
+                {"activitylog.addnewspecattribute", "Added a new specification attribute ('{0}')"},
+                {"activitylog.addnewtopic", "Added a new topic ('{0}')"},
+                {"activitylog.createknowledgebasearticle", "Created knowledgebase article ('{0}')"},
+                {"activitylog.createknowledgebasecategory", "Created knowledgebase category ('{0}')"},
+                {"activitylog.deleteproduct", "Deleted a product ('{0}')"},
+                {"activitylog.editcategory", "Edited a category ('{0}')"},
+                {"activitylog.editmanufacturer", "Edited a manufacturer ('{0}')"},
+                {"activitylog.editorder", "Edited an order (ID = {0}). See order notes for details"},
+                {"activitylog.editproduct", "Edited a product ('{0}')"},
+                {"activitylog.editproductattribute", "Edited a product attribute ('{0}')"},
+                {"activitylog.editreturnrequest", "Edited a return request (ID = {0})"},
+                {"activitylog.editsettings", "Edited settings"},
+                {"activitylog.editspecattribute","Edited a specification attribute ('{0}')"},
+                {"activitylog.edittopic", "Edited a topic ('{0}')"},
+                {"activitylog.interactiveformadd", "Add Interactive form - {0}"},
+                {"activitylog.sendemailfromadminpanel", "Email (from admin panel) {0}"},
+                {"activitylog.updateknowledgebasecategory", "Updated knowledgebase category ('{0}')"},
+
+            };
+    }
+}


### PR DESCRIPTION
Resolves #753  Activity log - Make links instead of text in log message
Type: **feature**

## Solution
LinkedCommentFormatter class adds the link to old activity log comment, already storing in DB.
It tries to find the comment's string pattern by system keyword, parses the comment, and changes the parameter of the comment to link.

LinkedCommentCreator class adding the link to the newly created activity log comment, which is about to insert to DB.
It uses comment's pattern, comment's parameters and activity log system keyword to create linked comment and store it to DB.

Links patterns to the entities are stored in ActivityEntityKeywordsProvider class.


## Breaking changes
1. CustomerActivityService.InsertActivity - on each invoke the method calls LinkedCommentCreator.CreateLinkedComment. 
In case CreateLinkedComment method throws an exception, it throws the exception further.

2. Cshtml view files are changed so that the column 'comments' are not encoded anymore - so the link is shown in the correct way. May be not safe.

## Testing
Added unit tests:
LinkedCommentFormatterTests
LinkedCommentCreatorTests
