### PR TITLE
Fix of 826: Allow staff to import manufacturers from excel

### DIFF
--- a/Grand.Web/Areas/Admin/Controllers/ManufacturerController.cs
+++ b/Grand.Web/Areas/Admin/Controllers/ManufacturerController.cs
@@ -343,8 +343,8 @@ namespace Grand.Web.Areas.Admin.Controllers
         [HttpPost]
         public async Task<IActionResult> ImportFromXlsx(IFormFile importexcelfile, [FromServices] IWorkContext workContext)
         {
-            //a vendor and staff cannot import manufacturers
-            if (workContext.CurrentVendor != null || _workContext.CurrentCustomer.IsStaff())
+            //a vendor cannot import manufacturers
+            if (workContext.CurrentVendor != null || _workContext.CurrentCustomer.IsVendor())
                 return AccessDeniedView();
 
             try


### PR DESCRIPTION
Resolves #826 

## Issue
Allow staff to import manufacturers from excel

## Solution
Remove checking `CurrentCustomer.IsStaff()` to allow import

## Breaking changes
- None

## Testing
1. Login with staff user & import excel file.
