### PR TITLE
support custom Amazon S3  endpoint URL

### DIFF
--- a/Grand.Core/Configuration/GrandConfig.cs
+++ b/Grand.Core/Configuration/GrandConfig.cs
@@ -87,6 +87,11 @@ namespace Grand.Core.Configuration
         public string AmazonBucketName { get; set; }
 
         /// <summary>
+        /// Custom Endpoint for third party S3 compatible service, example: https://sfo2.digitaloceanspaces.com
+        /// </summary>
+        public string AmazonRegionEndpoint { get; set; }
+
+        /// <summary>
         /// Amazon Domain name for cloudfront distribution
         /// </summary>
         public string AmazonDistributionDomainName { get; set; }

--- a/Grand.Services/Media/AmazonPictureService.cs
+++ b/Grand.Services/Media/AmazonPictureService.cs
@@ -62,13 +62,24 @@ namespace Grand.Services.Media
             if (string.IsNullOrEmpty(_config.AmazonBucketName))
                 throw new ArgumentNullException("AmazonBucketName");
 
-            //Region guard
-            var regionEndpoint = RegionEndpoint.GetBySystemName(_config.AmazonRegion);
-            if (regionEndpoint.DisplayName == "Unknown")
-                throw new NullReferenceException("specified Region is invalid");
+            AmazonS3Config amazonS3Config = new AmazonS3Config();
+
+            if (string.IsNullOrEmpty(_config.AmazonRegionEndpoint))
+            {
+                //Region guard
+                var regionEndpoint = RegionEndpoint.GetBySystemName(_config.AmazonRegion);
+                if (regionEndpoint.DisplayName == "Unknown")
+                    throw new NullReferenceException("specified Region is invalid");
+
+                amazonS3Config.RegionEndpoint = regionEndpoint;
+            }
+            else
+            {
+                amazonS3Config.ServiceURL = _config.AmazonRegionEndpoint;
+            }
 
             //Client guard
-            _s3Client = new AmazonS3Client(_config.AmazonAwsAccessKeyId, _config.AmazonAwsSecretAccessKey, regionEndpoint);
+            _s3Client = new AmazonS3Client(_config.AmazonAwsAccessKeyId, _config.AmazonAwsSecretAccessKey, amazonS3Config);
 
             //Bucket guard
             _bucketName = _config.AmazonBucketName;

--- a/Grand.Web/App_Data/appsettings.json
+++ b/Grand.Web/App_Data/appsettings.json
@@ -71,6 +71,7 @@
     "AmazonAwsSecretAccessKey": "",
     "AmazonBucketName": "",
     "AmazonRegion": "",
+    "AmazonRegionEndpoint": "", // third party S3 compatible service, example: https://sfo2.digitaloceanspaces.com
     "AmazonDistributionDomainName": "", //Domain name for cloudfront distribution
 
     ///Enable the Publish/Subscribe messaging with redis to manage memory cache on every server


### PR DESCRIPTION
Resolves #issueNumber  
Type: **feature|bugfix|**

## Issue
Current implementation only support Amazon S3. It does not work with other provider that is compatible with S3 service.

## Solution
By setting custom endpoint URL address, third party service can be used in place of Amazon S3

## Breaking changes
If you have a breaking changes, list them here, otherwise list none.

## Testing
1. List the steps needed for testing your PR.
2. Assume that everyone already know how to run the GrandNode, and do the basic configuration.
3. Be detailed enough that someone can work through it easily.
