### PR TITLE
Issue disable billing address

### DIFF
--- a/Grand.Web/Controllers/CheckoutController.cs
+++ b/Grand.Web/Controllers/CheckoutController.cs
@@ -257,7 +257,7 @@ namespace Grand.Web.Controllers
                 if (model.ExistingAddresses.Any())
                 {
                     //choose the first one
-                    return await SelectBillingAddress(model.ExistingAddresses.First().Id);
+                    return await SelectBillingAddress(model.ExistingAddresses.First().Id, false);
                 }
 
                 TryValidateModel(model);
@@ -1259,6 +1259,10 @@ namespace Grand.Web.Controllers
 
                     var model = new CheckoutBillingAddressModel();
                     await TryUpdateModelAsync(model);
+
+                    if (_orderSettings.DisableBillingAddressCheckoutStep)
+                        _shippingSettings.ShipToSameAddress = false;
+
                     if (_shippingSettings.ShipToSameAddress && model.ShipToSameAddress)
                     {
                         _workContext.CurrentCustomer.ShippingAddress = _workContext.CurrentCustomer.BillingAddress;

--- a/Grand.Web/Controllers/CheckoutController.cs
+++ b/Grand.Web/Controllers/CheckoutController.cs
@@ -257,7 +257,7 @@ namespace Grand.Web.Controllers
                 if (model.ExistingAddresses.Any())
                 {
                     //choose the first one
-                    return await SelectBillingAddress(model.ExistingAddresses.First().Id, false);
+                    return await SelectBillingAddress(model.ExistingAddresses.First().Id);
                 }
 
                 TryValidateModel(model);
@@ -1261,7 +1261,7 @@ namespace Grand.Web.Controllers
                     await TryUpdateModelAsync(model);
 
                     if (_orderSettings.DisableBillingAddressCheckoutStep)
-                        _shippingSettings.ShipToSameAddress = false;
+                        model.ShipToSameAddress = false;
 
                     if (_shippingSettings.ShipToSameAddress && model.ShipToSameAddress)
                     {


### PR DESCRIPTION
Resolves #issueNumber  
Type: bugfix

## Issue
If disable billing address is set to true, and ship to the same address is set to true, at checkout you can not choose any address

## Solution
Set ship to the same address as false to force display address form. 

## Testing
1. Set ship to same address set to true (/Admin/Setting/Shipping)
2. Set disable billing address (/Admin/Setting/Order)
3. Proceed to /cart for tests. 
