### PR TITLE
Fix avatar urls on forum posts

### DIFF
--- a/Grand.Web/Features/Handlers/Boards/GetForumTopicPageHandler.cs
+++ b/Grand.Web/Features/Handlers/Boards/GetForumTopicPageHandler.cs
@@ -112,9 +112,9 @@ namespace Grand.Web.Features.Handlers.Boards
                     forumPostModel.PostCreatedOnStr = _dateTimeHelper.ConvertToUserTime(post.CreatedOnUtc, DateTimeKind.Utc).ToString("f");
                 //avatar
                 if (_customerSettings.AllowCustomersToUploadAvatars)
-                {
+                {                    
                     forumPostModel.CustomerAvatarUrl = await _pictureService.GetPictureUrl(
-                        request.Customer.GetAttributeFromEntity<string>(SystemCustomerAttributeNames.AvatarPictureId),
+                        customer.GetAttributeFromEntity<string>(SystemCustomerAttributeNames.AvatarPictureId),
                         _mediaSettings.AvatarPictureSize,
                         _customerSettings.DefaultAvatarEnabled,
                         defaultPictureType: PictureType.Avatar);


### PR DESCRIPTION
Resolves #1026
Type: **bugfix**

## Issue
On forum posts, avatar urls are taken from logged-in user instead of post author.

## Solution
Use correct variable.

## Breaking changes

## Testing
1. Enable forum
2. Allow avatar upload for customers
3. Setup avatar for a customer
4. Write post on forum as the customer
5. Log off
6. Open post created by the customer
7. Validate if avatar shown is the same as uploaded (in contrary to default one)
