### PR TITLE
check if product has AllowedQuantities

### DIFF
--- a/Grand.Services/Orders/ShoppingCartService.cs
+++ b/Grand.Services/Orders/ShoppingCartService.cs
@@ -1291,7 +1291,7 @@ namespace Grand.Services.Orders
                 shoppingCartType, productId, warehouseId, attributes, customerEnteredPrice,
                 rentalStartDate, rentalEndDate);
 
-            if (shoppingCartItem != null && product.ProductType != ProductType.Reservation)
+            if (shoppingCartItem != null && product.ProductType != ProductType.Reservation && String.IsNullOrEmpty(product.AllowedQuantities))
             {
                 //update existing shopping cart item
                 shoppingCartItem.Quantity = shoppingCartItem.Quantity + quantity;


### PR DESCRIPTION
Resolves #1038   
Type: **bugfix**

## Issue
Product has allowed quantities of 10/50/100
Not able to add the double value of 10

## Solution
Should check if product has AllowedQuantities

## Testing
1. Go to product
2.  Click on add to cart quantity of 10
3. Click on the pop up continue to stay at the product page
4. Click again add to cart quantity of 10
In this case, adding a new order line should be executed instead of adding quantity.